### PR TITLE
Resolve context schema && add prev, next commands

### DIFF
--- a/python/mlad/cli/context.py
+++ b/python/mlad/cli/context.py
@@ -112,7 +112,6 @@ def use(name: str) -> Context:
         raise NotExistContextError(name)
 
     config.current = name
-    OmegaConf.save(config=config, f=CTX_PATH)
     _save(config)
     click.echo(f'Current context name is : {name}')
     return context
@@ -154,6 +153,8 @@ def get(name: Optional[str] = None) -> Context:
         name = config.current
 
     context = _find_context(name, config=config)
+    if context is None:
+        raise NotExistContextError(name)
     click.echo(OmegaConf.to_yaml(context))
     return context
 

--- a/python/mlad/cli/context.py
+++ b/python/mlad/cli/context.py
@@ -1,38 +1,58 @@
 import sys
 import os
 import omegaconf
+import click
 
 from typing import Optional, Dict, Callable
 from pathlib import Path
 from omegaconf import OmegaConf
 from mlad.cli.libs import utils
 from mlad.cli.exceptions import (
-    NotExistContextError, CannotDeleteContextError, NotExistDefaultContextError,
-    InvalidPropertyError, ContextAlreadyExistError
+    NotExistContextError, CannotDeleteContextError, InvalidPropertyError,
+    ContextAlreadyExistError
 )
 
 
 MLAD_HOME_PATH = f'{Path.home()}/.mlad'
 DIR_PATH = f'{MLAD_HOME_PATH}/contexts'
 REF_PATH = f'{MLAD_HOME_PATH}/context_ref.yml'
+CTX_PATH = f'{MLAD_HOME_PATH}/context.yml'
 Path(DIR_PATH).mkdir(exist_ok=True, parents=True)
+Config = omegaconf.Container
 Context = omegaconf.Container
 StrDict = Dict[str, str]
 
 isfile = os.path.isfile
 
+boilerplate = {
+    'current': None,
+    'contexts': []
+}
+OmegaConf.save(config=boilerplate, f=CTX_PATH)
 
-def ctx_path(name: str) -> str:
-    return f'{DIR_PATH}/{name}.yml'
+
+def _load():
+    return OmegaConf.load(CTX_PATH)
 
 
-def path_to_name(path: str) -> str:
-    return os.path.splitext(path.split('/')[-1])[0]
+def _save(config: Config):
+    OmegaConf.save(config=config, f=CTX_PATH)
+
+
+def _find_context(name: str, config: Optional[Config] = None, index: bool = False) -> Optional[Context]:
+    if config is None:
+        config = OmegaConf.load(CTX_PATH)
+
+    for i, context in enumerate(config.contexts):
+        if context.name == name:
+            return context if not index else i
+
+    return None
 
 
 def add(name: str, address: str) -> Context:
 
-    if isfile(ctx_path(name)):
+    if _find_context(name) is not None:
         raise ContextAlreadyExistError(name)
     address = utils.parse_url(address)['url']
     registry_address = 'https://docker.io'
@@ -49,6 +69,7 @@ def add(name: str, address: str) -> Context:
     registry_namespace = utils.prompt('Docker Registry Namespace')
 
     base_config = OmegaConf.from_dotlist([
+        f'name={name}',
         f'apiserver.address={address}',
         f'docker.registry.address={registry_address}',
         f'docker.registry.namespace={registry_namespace}'
@@ -70,7 +91,11 @@ def add(name: str, address: str) -> Context:
     db_config = _parse_datastore('db', _db_initializer, _db_finalizer, db_prompts)
 
     context = OmegaConf.merge(base_config, s3_config, db_config)
-    OmegaConf.save(config=context, f=ctx_path(name))
+    config = _load()
+    config.contexts.append(context)
+    if config.current is None:
+        config.current = name
+    _save(config)
 
     if warn_insecure:
         print('Need to add insecure-registry to docker.json on your all nodes.', file=sys.stderr)
@@ -81,52 +106,64 @@ def add(name: str, address: str) -> Context:
 
 
 def use(name: str) -> Context:
-    target_path = ctx_path(name)
-
-    if not isfile(target_path):
+    config = _load()
+    context = _find_context(name, config=config)
+    if context is None:
         raise NotExistContextError(name)
-    context = OmegaConf.create({'target': target_path})
-    OmegaConf.save(config=context, f=REF_PATH)
+
+    config.current = name
+    OmegaConf.save(config=config, f=CTX_PATH)
+    _save(config)
+    click.echo(f'Current context name is : {name}')
     return context
 
 
+def _switch(direction: int = 1) -> Context:
+    config = _load()
+    if config.current is None:
+        raise NotExistContextError('Any Contexts')
+    n_contexts = len(config.contexts)
+    index = _find_context(config.current, config=config, index=True)
+    next_index = (index + direction) % n_contexts
+    return use(config.contexts[next_index].name)
+
+
+def next() -> Context:
+    return _switch(direction=1)
+
+
+def prev() -> Context:
+    return _switch(direction=-1)
+
+
 def delete(name: str) -> None:
-    target_path = ctx_path(name)
-    if isfile(REF_PATH):
-        curr_path = OmegaConf.load(REF_PATH).target
-        if target_path == curr_path:
-            raise CannotDeleteContextError
-    try:
-        os.remove(target_path)
-    except FileNotFoundError:
+    config = _load()
+    index = _find_context(name, config=config, index=True)
+    if index is None:
         raise NotExistContextError(name)
+    elif config.current == config.contexts[index].name:
+        raise CannotDeleteContextError
+    else:
+        del config.contexts[index]
+    _save(config)
 
 
 def get(name: Optional[str] = None) -> Context:
-
+    config = _load()
     if name is None:
-        if not isfile(REF_PATH):
-            raise NotExistDefaultContextError
-        target_path = OmegaConf.load(REF_PATH).target
-        return get(path_to_name(target_path))
+        name = config.current
 
-    target_path = ctx_path(name)
-    if not isfile(target_path):
-        raise NotExistContextError(name)
-
-    context = OmegaConf.load(ctx_path(name))
-    print(OmegaConf.to_yaml(context))
+    context = _find_context(name, config=config)
+    click.echo(OmegaConf.to_yaml(context))
     return context
 
 
 def set(name: Optional[str] = None, *args) -> None:
+    config = _load()
     if name is None:
-        if not isfile(REF_PATH):
-            raise NotExistDefaultContextError
-        target_path = OmegaConf.load(REF_PATH).target
-        return set(path_to_name(target_path), *args)
-
-    context = OmegaConf.load(ctx_path(name))
+        name = config.current
+    index = _find_context(name, config=config, index=True)
+    context = config.contexts[index]
     try:
         for arg in args:
             keys = arg.split('=')[0].split('.')
@@ -135,15 +172,18 @@ def set(name: Optional[str] = None, *args) -> None:
                 value = value[key]
     except Exception:
         raise InvalidPropertyError(arg)
+
     context = OmegaConf.merge(context, OmegaConf.from_dotlist(args))
-    OmegaConf.save(config=context, f=ctx_path(name))
+    OmegaConf.update(config, f'contexts.{index}', context)
+    _save(config)
 
 
 def ls(no_trunc):
-    names = [os.path.splitext(filename)[0] for filename in os.listdir(DIR_PATH)]
+    config = _load()
+    names = [context.name for context in config.contexts]
     table = [('NAME',)]
     for name in names:
-        table.append([name])
+        table.append([name if config.current != name else f'* {name}'])
     utils.print_table(table, 'There are no contexts.', 0 if no_trunc else 32)
 
 

--- a/python/mlad/cli/exceptions.py
+++ b/python/mlad/cli/exceptions.py
@@ -15,12 +15,6 @@ class ContextAlreadyExistError(Exception):
         return f'The context [{self._name}] already exists.'
 
 
-class NotExistDefaultContextError(Exception):
-
-    def __str__(self):
-        return 'There is no default context, please set any context to default.'
-
-
 class NotExistContextError(Exception):
 
     def __init__(self, name: str):

--- a/python/tests/context/mock.py
+++ b/python/tests/context/mock.py
@@ -4,23 +4,21 @@ import shutil
 
 from mlad.cli import context
 from pathlib import Path
+from omegaconf import OmegaConf
 
 origin_stdin = None
 
 
 def setup():
-    context.DIR_PATH = './tests/contexts'
-    context.REF_PATH = './tests/context_ref.yml'
-    context.ctx_path = lambda name: f'{context.DIR_PATH}/{name}.yml'
-    Path('./tests/contexts').mkdir(exist_ok=True, parents=True)
+    context.CTX_PATH = './tests/context.yml'
+    Path('./tests').mkdir(exist_ok=True, parents=True)
+    OmegaConf.save(config=context.boilerplate, f=context.CTX_PATH)
     global origin_stdin
     origin_stdin = sys.stdin
 
 
 def teardown():
-    context.DIR_PATH = f'{context.MLAD_HOME_PATH}/contexts'
-    context.REF_PATH = f'{context.MLAD_HOME_PATH}/context_ref.yml'
-    context.ctx_path = lambda name: f'{context.DIR_PATH}/{name}.yml'
+    context.CTX_PATH = f'{context.MLAD_HOME_PATH}/context.yml'
     shutil.rmtree('./tests')
     global origin_stdin
     sys.stdin = origin_stdin

--- a/python/tests/context/test_add.py
+++ b/python/tests/context/test_add.py
@@ -1,6 +1,5 @@
 import sys
 import io
-import os
 import pytest
 
 from omegaconf import OmegaConf
@@ -34,6 +33,7 @@ def test_valid_input():
     ]
     sys.stdin = io.StringIO(''.join([f'{_}\n' for _ in inputs[1:]]))
     expected = {
+        'name': 'test-valid',
         'apiserver': {'address': inputs[0]},
         'docker': {'registry': {'address': inputs[1], 'namespace': 'gameai'}},
         'datastore': {
@@ -52,7 +52,7 @@ def test_valid_input():
         }
     }
     assert expected == OmegaConf.to_object(context.add('test-valid', inputs[0]))
-    assert os.path.isfile(context.ctx_path('test-valid'))
+    assert expected == context._find_context('test-valid')
 
 
 def test_valid_input2():
@@ -70,6 +70,7 @@ def test_valid_input2():
     ]
     sys.stdin = io.StringIO(''.join([f'{_}\n' for _ in inputs[1:]]))
     expected = {
+        'name': 'test-valid2',
         'apiserver': {'address': inputs[0]},
         'docker': {'registry': {'address': inputs[1], 'namespace': None}},
         'datastore': {
@@ -88,7 +89,7 @@ def test_valid_input2():
         }
     }
     assert expected == OmegaConf.to_object(context.add('test-valid2', inputs[0]))
-    assert os.path.isfile(context.ctx_path('test-valid2'))
+    assert expected == context._find_context('test-valid2')
 
 
 def test_invalid_input():

--- a/python/tests/context/test_delete.py
+++ b/python/tests/context/test_delete.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 
 from mlad.cli import context
@@ -18,12 +17,15 @@ def teardown_module():
 def test_delete():
     mock.add('test1')
     mock.add('test2')
+    mock.add('test3')
     context.use('test1')
     context.delete('test2')
 
-    assert not os.path.isfile(context.ctx_path('test2'))
+    assert context._find_context('test2') is None
+    config = context._load()
+    assert ['test1', 'test3'] == [context.name for context in config.contexts]
     with pytest.raises(CannotDeleteContextError):
         context.delete('test1')
 
     with pytest.raises(NotExistContextError):
-        context.delete('test3')
+        context.delete('test4')

--- a/python/tests/context/test_get.py
+++ b/python/tests/context/test_get.py
@@ -2,9 +2,7 @@ import os
 import pytest
 
 from mlad.cli import context
-from mlad.cli.exceptions import (
-    NotExistDefaultContextError, NotExistContextError
-)
+from mlad.cli.exceptions import NotExistContextError
 
 from . import mock
 
@@ -37,12 +35,3 @@ def test_get():
     context.get('test1')
     with pytest.raises(NotExistContextError):
         context.get('test2')
-
-
-def test_default():
-    mock.add('test1')
-    with pytest.raises(NotExistDefaultContextError):
-        context.get()
-
-    context.use('test1')
-    context.get()

--- a/python/tests/context/test_get.py
+++ b/python/tests/context/test_get.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 
 from mlad.cli import context
@@ -13,18 +12,6 @@ def setup_module():
 
 def teardown_module():
     mock.teardown()
-
-
-def teardown_function():
-    remove_paths = [
-        context.ctx_path('test1'),
-        context.REF_PATH
-    ]
-    for path in remove_paths:
-        try:
-            os.remove(path)
-        except FileNotFoundError:
-            continue
 
 
 def test_get():

--- a/python/tests/context/test_ls.py
+++ b/python/tests/context/test_ls.py
@@ -6,11 +6,11 @@ from mlad.cli import context
 from . import mock
 
 
-def setup_module():
+def setup_function():
     mock.setup()
 
 
-def teardown_module():
+def teardown_function():
     mock.teardown()
 
 
@@ -20,10 +20,8 @@ def test_ls():
     mock.add('test2')
     sys.stdout = buffer = io.StringIO()
     context.ls(False)
-    assert buffer.getvalue() == 'NAME \ntest2\ntest1\n'
     sys.stdout = origin_stdout
-    context.delete('test1')
-    context.delete('test2')
+    assert buffer.getvalue() == 'NAME   \n* test1\ntest2  \n'
 
 
 def test_blank_ls():

--- a/python/tests/context/test_set.py
+++ b/python/tests/context/test_set.py
@@ -2,9 +2,7 @@ import pytest
 
 from omegaconf import OmegaConf
 from mlad.cli import context
-from mlad.cli.exceptions import (
-    InvalidPropertyError, NotExistDefaultContextError
-)
+from mlad.cli.exceptions import InvalidPropertyError
 
 from . import mock
 
@@ -25,6 +23,7 @@ def test_set():
                 'datastore.s3.verify=False')
 
     expected = {
+        'name': 'test1',
         'apiserver': {'address': 'https://ncml-dev.cloud.ncsoft.com'},
         'docker': {'registry': {
             'address': 'https://harbor.sailio.ncsoft.com',
@@ -50,9 +49,6 @@ def test_set():
 
 
 def test_invalid_set():
-    with pytest.raises(NotExistDefaultContextError):
-        context.set(None, 'docker.registry.namespace=null')
-
     mock.add('test2')
     context.use('test2')
     context.set(None, 'datastore.db.address=mongodb://8.8.8.8:27017')

--- a/python/tests/context/test_switch.py
+++ b/python/tests/context/test_switch.py
@@ -1,0 +1,45 @@
+import pytest
+
+from mlad.cli import context
+from mlad.cli.exceptions import NotExistContextError
+
+from . import mock
+
+origin_stdin = None
+
+
+def setup_function():
+    mock.setup()
+
+
+def teardown_function():
+    mock.teardown()
+
+
+def test_next():
+    for index in range(5):
+        mock.add(f'next-{index}')
+    config = context._load()
+    assert config.current == 'next-0'
+    for index in range(5):
+        context.next()
+        config = context._load()
+        config.current == f'next-{(index + 1) % 5}'
+
+
+def test_prev():
+    for index in range(5):
+        mock.add(f'prev-{index}')
+    config = context._load()
+    assert config.current == 'prev-0'
+    for index in range(5):
+        context.next()
+        config = context._load()
+        config.current == f'prev-{(5 - index) % 5}'
+
+
+def test_invalid_use():
+    with pytest.raises(NotExistContextError):
+        context.next()
+    with pytest.raises(NotExistContextError):
+        context.prev()

--- a/python/tests/context/test_use.py
+++ b/python/tests/context/test_use.py
@@ -1,8 +1,5 @@
-import sys
-import io
 import pytest
 
-from omegaconf import OmegaConf
 from mlad.cli import context
 from mlad.cli.exceptions import NotExistContextError
 
@@ -20,23 +17,10 @@ def teardown_module():
 
 
 def test_use():
-    inputs = [
-        'https://ncml-dev.cloud.ncsoft.com',
-        'https://harbor.sailio.ncsoft.com',
-        'gameai',
-        'https://localhost:9000',
-        'us-west-1',
-        'minioadmin',
-        'minioadmin',
-        'mongodb://localhost:27017',
-        'dbadmin',
-        'dbadmin'
-    ]
-    sys.stdin = io.StringIO(''.join([f'{_}\n' for _ in inputs[1:]]))
-    context.add('use', inputs[0])
+    mock.add('use')
     context.use('use')
-    config = OmegaConf.load(context.REF_PATH)
-    assert config.target == context.ctx_path('use')
+    config = context._load()
+    assert config.current == 'use'
 
 
 def test_invalid_use():


### PR DESCRIPTION
Resolves #25 

`context.yml`에 스키마에 맞춰서 저장하도록 변경하였습니다.
`prev`, `next` 기능을 추가하였습니다.
`prev`, `next`의 unit test를 추가하였습니다.