### PR TITLE
Replace config logic to the context module

### DIFF
--- a/python/mlad/cli/autocompletion.py
+++ b/python/mlad/cli/autocompletion.py
@@ -3,6 +3,7 @@ import os
 import glob
 from omegaconf import OmegaConf
 from mlad.core.default import project as default_project
+from mlad.core.default.config import service_config
 from mlad.core.docker import controller as ctlr
 from mlad.cli.libs import utils
 from mlad.cli import config as config_core
@@ -26,7 +27,7 @@ def get_dir_completion(ctx, args, incomplete):
 def get_node_list_completion(ctx, args, incomplete):
     config = config_core.get()
     try:
-        with API(config.mlad.address, config.mlad.token.admin) as api:
+        with API(config.apiserver.address, config.session) as api:
             nodes = [api.node.inspect(_) for _ in api.node.get()]
     except APIError as e:
         print(e)
@@ -40,7 +41,7 @@ def get_node_label_completion(ctx, args, incomplete):
     config = config_core.get()
     node_key = args[args.index('label') + 1]
     try:
-        with API(config.mlad.address, config.mlad.token.admin) as api:
+        with API(config.apiserver.address, config.session) as api:
             node = api.node.inspect(node_key)
     except APIError as e:
         print(e)
@@ -66,8 +67,7 @@ def get_config_key_completion(ctx, args, incomplete):
 
 
 def get_image_list_completion(ctx, args, incomplete):
-    config = config_core.get()
-    cli = ctlr.get_api_client(config['docker']['host'])
+    cli = ctlr.get_api_client()
     images = ctlr.get_images(cli)
     inspects = [ctlr.inspect_image(_) for _ in images]
     repos = [f"{_['repository']}{':'+_['tag'] if _['tag'] else ''}" for _ in inspects]
@@ -105,7 +105,7 @@ def get_running_services_completion(ctx, args, incomplete):
         utils.apply_project_arguments(project_file[-1], None)
     project_key = utils.project_key(utils.get_workspace())
     try:
-        with API(config.mlad.address, config.mlad.token.user) as api:
+        with API(config.apiserver.address, config.session) as api:
             services = [_['name'] for _ in api.service.get(project_key)['inspects']]
     except APIError as e:
         print(e)
@@ -121,7 +121,7 @@ def get_running_services_tasks_completion(ctx, args, incomplete):
         utils.apply_project_arguments(project_file[-1], None)
     project_key = utils.project_key(utils.get_workspace())
     try:
-        with API(config.mlad.address, config.mlad.token.user) as api:
+        with API(config.apiserver.address, config.session) as api:
             services = dict([(_['name'], _['tasks']) for _ in api.service.get(project_key)['inspects']])
     except APIError as e:
         print(e)

--- a/python/mlad/cli/autocompletion.py
+++ b/python/mlad/cli/autocompletion.py
@@ -5,22 +5,26 @@ from omegaconf import OmegaConf
 from mlad.core.default import project as default_project
 from mlad.core.docker import controller as ctlr
 from mlad.cli.libs import utils
+from mlad.cli import config as config_core
 from mlad.api import API
 from mlad.api.exception import APIError
 
+
 def get_project_file_completion(ctx, args, incomplete):
-    files = glob.glob(f"{incomplete}*" or '*')    
+    files = glob.glob(f"{incomplete}*" or '*')
     subcommands = [f"{_}/" for _ in files if os.path.isdir(_)]
     subcommands += [_ for _ in files if _.endswith('.yaml') or _.endswith('.yml')]
     return subcommands
 
+
 def get_dir_completion(ctx, args, incomplete):
-    files = glob.glob(f"{incomplete}*" or '*')    
+    files = glob.glob(f"{incomplete}*" or '*')
     subcommands = [f"{_}/" for _ in files if os.path.isdir(_)]
     return subcommands
 
+
 def get_node_list_completion(ctx, args, incomplete):
-    config = utils.read_config()
+    config = config_core.get()
     try:
         with API(config.mlad.address, config.mlad.token.admin) as api:
             nodes = [api.node.inspect(_) for _ in api.node.get()]
@@ -31,9 +35,10 @@ def get_node_list_completion(ctx, args, incomplete):
     ids = [_['id'][:ctlr.SHORT_LEN] for _ in nodes] if incomplete else []
     return [_ for _ in hostnames + ids if _.startswith(incomplete)]
 
+
 def get_node_label_completion(ctx, args, incomplete):
-    config = utils.read_config()
-    node_key = args[args.index('label')+1]
+    config = config_core.get()
+    node_key = args[args.index('label') + 1]
     try:
         with API(config.mlad.address, config.mlad.token.admin) as api:
             node = api.node.inspect(node_key)
@@ -42,9 +47,11 @@ def get_node_label_completion(ctx, args, incomplete):
         sys.exit(1)
     keys = [f'{key}' for key, value in node['labels'].items()]
     return [_ for _ in keys if _.startswith(incomplete)]
-    
+
+
 def get_config_key_completion(ctx, args, incomplete):
-    config = OmegaConf.to_container(utils.read_config(), resolve=True)
+    config = OmegaConf.to_container(config_core.get(), resolve=True)
+
     def compose_keys(config, stack=[]):
         keys = []
         for k, v in config.items():
@@ -55,10 +62,11 @@ def get_config_key_completion(ctx, args, incomplete):
                 keys.append('.'.join(stack))
             stack.pop(-1)
         return keys
-    return [_ for _ in compose_keys(config) if _.startswith(incomplete)] 
+    return [_ for _ in compose_keys(config) if _.startswith(incomplete)]
+
 
 def get_image_list_completion(ctx, args, incomplete):
-    config = utils.read_config()
+    config = config_core.get()
     cli = ctlr.get_api_client(config['docker']['host'])
     images = ctlr.get_images(cli)
     inspects = [ctlr.inspect_image(_) for _ in images]
@@ -66,28 +74,35 @@ def get_image_list_completion(ctx, args, incomplete):
     if incomplete:
         separated_repos = [__ for _ in repos for __ in _.split(':')]
         ids = [_['short_id'] for _ in inspects]
-        return [_ for _ in set(separated_repos+ids) if _.startswith(incomplete)]
+        return [_ for _ in set(separated_repos + ids) if _.startswith(incomplete)]
     else:
         return [_ for _ in repos if _.startswith(incomplete)]
 
+
 def get_stopped_services_completion(ctx, args, incomplete):
-    config = utils.read_config()
-    project_file = [_ for _ in [args[i+1] for i, _ in enumerate(args[:-1]) if _ in ['-f', '--file']] if os.path.isfile(_)]
-    if project_file: utils.apply_project_arguments(project_file[-1], None)
+    config = config_core.get()
+    project_file = [_ for _ in [args[i + 1] for i, _ in enumerate(args[:-1])
+                    if _ in ['-f', '--file']] if os.path.isfile(_)]
+    if project_file:
+        utils.apply_project_arguments(project_file[-1], None)
     project = utils.get_project(default_project)
     project_key = utils.project_key(utils.get_workspace())
     try:
         with API(config.mlad.address, config.mlad.token.user) as api:
             services = [_['name'] for _ in api.service.get(project_key)['inspects']]
-    except APIErro as e:
+    except APIError as e:
         print(e)
         sys.exit(1)
-    return [_ for _ in project['services'] if _.startswith(incomplete) and not _ in services]
+    return [_ for _ in project['services']
+            if _.startswith(incomplete) and _ not in services]
+
 
 def get_running_services_completion(ctx, args, incomplete):
-    config = utils.read_config()
-    project_file = [_ for _ in [args[i+1] for i, _ in enumerate(args[:-1]) if _ in ['-f', '--file']] if os.path.isfile(_)]
-    if project_file: utils.apply_project_arguments(project_file[-1], None)
+    config = config_core.get()
+    project_file = [_ for _ in [args[i + 1] for i, _ in enumerate(args[:-1])
+                    if _ in ['-f', '--file']] if os.path.isfile(_)]
+    if project_file:
+        utils.apply_project_arguments(project_file[-1], None)
     project_key = utils.project_key(utils.get_workspace())
     try:
         with API(config.mlad.address, config.mlad.token.user) as api:
@@ -97,10 +112,13 @@ def get_running_services_completion(ctx, args, incomplete):
         sys.exit(1)
     return [_ for _ in services if _.startswith(incomplete)]
 
+
 def get_running_services_tasks_completion(ctx, args, incomplete):
-    config = utils.read_config()
-    project_file = [_ for _ in [args[i+1] for i, _ in enumerate(args[:-1]) if _ in ['-f', '--file']] if os.path.isfile(_)]
-    if project_file: utils.apply_project_arguments(project_file[-1], None)
+    config = config_core.get()
+    project_file = [_ for _ in [args[i + 1] for i, _ in enumerate(args[:-1])
+                    if _ in ['-f', '--file']] if os.path.isfile(_)]
+    if project_file:
+        utils.apply_project_arguments(project_file[-1], None)
     project_key = utils.project_key(utils.get_workspace())
     try:
         with API(config.mlad.address, config.mlad.token.user) as api:

--- a/python/mlad/cli/config.py
+++ b/python/mlad/cli/config.py
@@ -1,199 +1,36 @@
-import sys
-import os
-import uuid
-from omegaconf import OmegaConf
-from getpass import getuser
+from typing import Tuple, List
 
-from mlad.cli.libs import utils
-from mlad.cli.libs import datastore as ds
-from mlad.core.default import config as default_config
+from mlad.cli import context
 
 
-def get_value(config, keys, stack=[]):
-    if not keys:
-        data = []
-        for key in config:
-            if isinstance(config[key], dict):
-                data = data + get_value(config[key], keys, stack + [key])
-            else:
-                data.append(('.'.join(stack + [key]), config[key]))
-        return data
-    else:
-        head = config
-        try:
-            for key in keys.split('.'):
-                stack.append(key)
-                head = head[key]
-            if not isinstance(head, dict):
-                return head
-            else:
-                print('Value is expandable.', file=sys.stderr)
-        except KeyError:
-            print('Cannot find config key.', file=sys.stderr)
-        sys.exit(1)
+def init(address) -> context.Context:
+    ctx = context.add('default', address, allow_duplicate=True)
+    context.use('default')
+    return ctx
 
 
-def init(address):
-    # address
-    address = utils.parse_url(address)['url']
-
-    if utils.has_config():
-        input = utils.prompt("Change the existing session key (Y/N)", "N").upper()
-        session = utils.create_session_key() if input == 'Y' else utils.read_config().mlad.session
-    else:
-        session = utils.create_session_key()
-
-    # registry
-    registry_address = 'https://docker.io'
-    warn_insecure = False
-    service_addr = utils.get_advertise_addr()
-    registry_port = utils.get_default_service_port('mlad_registry', 5000)
-    if registry_port:
-        registry_address = f'http://{service_addr}:{registry_port}'
-        #print(f'Detected Docker Registry[{registry_address}] on docker host.')
-    registry_address = utils.prompt("Docker Registry Address", registry_address)
-    parsed_url = utils.parse_url(registry_address)
-    if parsed_url['scheme'] != 'https':
-        warn_insecure = True
-    registry_address = parsed_url['url']
-    registry_namespace = utils.prompt("Docker Registry Namespace")
-    utils.generate_empty_config()
-    set(*(
-        f"mlad.address={address}",
-        f"mlad.session={session}",
-        f'docker.registry.address={registry_address}',
-        f'docker.registry.namespace={registry_namespace}'
-    ))
-    datastore()
-
-    print('\nRESULT')
-    get(None)
-
-    if warn_insecure:
-        print()
-        print(f"Need to add insecure-registry to docker.json on your all nodes.", file=sys.stderr)
-        print(f"/etc/docker/daemon.json:", file=sys.stderr)
-        print(f"  \"insecure-registries\": [\"{registry_address}\"]", file=sys.stderr)
+def set(*args) -> None:
+    return context.set('default', *args)
 
 
-def set(*args):
-    config = default_config['client'](utils.read_config())
-    config = OmegaConf.merge(config, OmegaConf.from_dotlist(args))
-    utils.write_config(config)
+def get() -> context.Context:
+    return context.get('default')
 
 
-def get(keys, no_trunc=False):
-    config = default_config['client'](utils.read_config())
-    data = get_value(OmegaConf.to_container(config, resolve=True), keys)
-    if isinstance(data, list):
-        table = [["KEY", "VALUE"]]
-        for key, value in data:
-            if key: table.append([key, str(value)])
-        utils.print_table(*([table, 'No have configuration values.'] + ([0] if no_trunc else [])))
-    else:
-        print(data)
-
-
-def env(unset):
-    config = default_config['client'](utils.read_config())
-    envs = ds.get_env(config)
+def env(unset=False) -> Tuple[List[str], str]:
+    ctx = get()
+    envs = context.get_env(ctx)
+    ret = []
     for line in envs:
         if unset:
-            K, V = line.split('=')
-            print(f'export {K}=')
+            K, _ = line.split('=')
+            ret.append(f'export {K}=')
         else:
-            print(f'export {line}')
-    print(f'# To set environment variables, run "eval $(mlad config env)"')
+            ret.append(f'export {line}')
+    msg = '# To set environment variables, run "eval $(mlad config env)"'
+    return ret, msg
 
 
-# Extension for DataStore
-def datastore(kind=None):
-    if not kind:
-        for _ in ds.datastores.keys():
-            datastore(_)
-        return
-    else:
-        if not kind in ds.datastores:
-            print('Cannot support datastore type.', file=sys.stderr)
-            print(f"Support DataStore Type [{', '.join(ds.datastores.keys())}]", file=sys.stderr)
-            sys.exit(1)
-    store = ds.datastores[kind]
-    config = store['initializer']()
-    for k, v in store['prompt'].items():
-        config[k] = utils.prompt(v, config[k])
-    config = store['finalizer'](config)    
-    set(*[f"datastore.{kind}.{k}={v}" for k, v in config.items()])
-
-
-# S3 DataStore
-def _datastore_s3_initializer():
-    # specific controlling docker
-    service_addr = utils.get_advertise_addr()
-    minio_port = utils.get_default_service_port('mlad_minio', 9000)
-    if minio_port:
-        endpoint = f'http://{service_addr}:{minio_port}'
-        region = 'ap-northeast-2'
-        access_key = 'MLAPPDEPLOY'
-        secret_key = 'MLAPPDEPLOY'
-    else:
-        endpoint = 'https://s3.amazonaws.com'
-        region = 'us-east-1'
-        access_key = None
-        secret_key = None
-    return {'endpoint': endpoint, 'region': region, 'accesskey': access_key, 'secretkey': secret_key}
-
-
-def _datastore_s3_finalizer(datastore):
-    parsed = utils.parse_url(datastore['endpoint'])
-    datastore['endpoint'] = parsed['url']
-    datastore['verify'] = parsed['scheme'] == 'https'
-    return datastore
-
-
-def _datastore_s3_translator(kind, key, value):
-    if key == 'endpoint':
-        return f"S3_ENDPOINT={value}"
-    elif key == 'verify':
-        return [f"S3_USE_HTTPS={1 if value else 0}", f"S3_VERIFY_SSL=0"]
-    elif key == 'accesskey':
-        return f"AWS_ACCESS_KEY_ID={value}"
-    elif key == 'secretkey':
-        return f"AWS_SECRET_ACCESS_KEY={value}"
-    elif key == 'region':
-        return f"AWS_REGION={value}"
-    else:
-        return f"{kind.upper()}_{key.upper()}={value}"
-
-ds.add_datastore('s3',
-        _datastore_s3_initializer, 
-        _datastore_s3_finalizer,
-        _datastore_s3_translator,
-        endpoint='S3 Compatible Address',
-        region='Region',
-        accesskey='Access Key ID',
-        secretkey='Secret Access Key')
-
-
-# MongoDB DataStore
-def _datastore_mongodb_initializer():
-    # specific controlling docker
-    service_addr = utils.get_advertise_addr()
-    mongo_port = utils.get_default_service_port('mlad_mongodb', 27017)
-    if mongo_port:
-        address = f"mongodb://{service_addr}:{mongo_port}"
-    else:
-        address = f"mongodb://localhost:27017"
-    return {'address': address, 'username': '', 'password': ''}
-
-def _datastore_mongodb_finalizer(datastore):
-    parsed = utils.parse_url(datastore['address'])
-    datastore['address'] = f"mongodb://{parsed['address']}"
-    return datastore
-
-ds.add_datastore('mongodb',
-        _datastore_mongodb_initializer, 
-        _datastore_mongodb_finalizer, 
-        address='MongoDB Address',
-        username='MongoDB Username',
-        password='MongoDB Password')
-
+def get_env():
+    ctx = get()
+    return context.get_env(ctx)

--- a/python/mlad/cli/context.py
+++ b/python/mlad/cli/context.py
@@ -1,9 +1,8 @@
 import sys
 import os
 import omegaconf
-import click
 
-from typing import Optional, Dict, Callable
+from typing import Optional, Dict, Callable, List
 from pathlib import Path
 from omegaconf import OmegaConf
 from mlad.cli.libs import utils
@@ -50,10 +49,19 @@ def _find_context(name: str, config: Optional[Config] = None, index: bool = Fals
     return None
 
 
-def add(name: str, address: str) -> Context:
+def add(name: str, address: str, allow_duplicate=False) -> Context:
 
-    if _find_context(name) is not None:
-        raise ContextAlreadyExistError(name)
+    config = _load()
+    duplicated_index = _find_context(name, config=config, index=True)
+    if duplicated_index is not None:
+        if not allow_duplicate:
+            raise ContextAlreadyExistError(name)
+        elif utils.prompt('Change the existing session key (Y/N)?', 'N') == 'Y':
+            session = utils.create_session_key()
+        else:
+            session = config.contexts[duplicated_index].session
+    else:
+        session = utils.create_session_key()
     address = utils.parse_url(address)['url']
     registry_address = 'https://docker.io'
     warn_insecure = False
@@ -70,6 +78,7 @@ def add(name: str, address: str) -> Context:
 
     base_config = OmegaConf.from_dotlist([
         f'name={name}',
+        f'session={session}',
         f'apiserver.address={address}',
         f'docker.registry.address={registry_address}',
         f'docker.registry.namespace={registry_namespace}'
@@ -91,10 +100,13 @@ def add(name: str, address: str) -> Context:
     db_config = _parse_datastore('db', _db_initializer, _db_finalizer, db_prompts)
 
     context = OmegaConf.merge(base_config, s3_config, db_config)
-    config = _load()
-    config.contexts.append(context)
+    if duplicated_index is not None:
+        config.contexts[duplicated_index] = context
+    else:
+        config.contexts.append(context)
     if config.current is None:
         config.current = name
+
     _save(config)
 
     if warn_insecure:
@@ -220,19 +232,27 @@ def _s3_finalizer(datastore: StrDict) -> StrDict:
     return datastore
 
 
-def _datastore_s3_translator(kind, key, value):
-    if key == 'endpoint':
-        return f'S3_ENDPOINT={value}'
-    elif key == 'verify':
-        return [f'S3_USE_HTTPS={1 if value else 0}', 'S3_VERIFY_SSL=0']
-    elif key == 'accesskey':
-        return f'AWS_ACCESS_KEY_ID={value}'
-    elif key == 'secretkey':
-        return f'AWS_SECRET_ACCESS_KEY={value}'
-    elif key == 'region':
-        return f'AWS_REGION={value}'
-    else:
-        return f'{kind.upper()}_{key.upper()}={value}'
+def get_env(context: Context) -> List[str]:
+    envs = []
+    for k, v in context['datastore']['s3'].items():
+        if k == 'endpoint':
+            envs.append(f'S3_ENDPOINT={v}')
+        elif k == 'verify':
+            envs.append(f'S3_USE_HTTPS={1 if v else 0}')
+            envs.append('S3_VERIFY_SSL=0')
+        elif k == 'accesskey':
+            envs.append(f'AWS_ACCESS_KEY_ID={v}')
+        elif k == 'secretkey':
+            envs.append(f'AWS_SECRET_ACCESS_KEY={v}')
+        elif k == 'region':
+            envs.append(f'AWS_REGION={v}')
+        else:
+            envs.append(f'S3_{k.upper()}={v}')
+
+    for k, v in context['datastore']['db'].items():
+        envs.append(f'DB_{k.upper()}={v}')
+    envs = sorted(envs)
+    return envs
 
 
 def _db_initializer() -> StrDict:

--- a/python/mlad/cli/context.py
+++ b/python/mlad/cli/context.py
@@ -13,16 +13,13 @@ from mlad.cli.exceptions import (
 
 
 MLAD_HOME_PATH = f'{Path.home()}/.mlad'
-DIR_PATH = f'{MLAD_HOME_PATH}/contexts'
-REF_PATH = f'{MLAD_HOME_PATH}/context_ref.yml'
-CTX_PATH = f'{MLAD_HOME_PATH}/context.yml'
-Path(DIR_PATH).mkdir(exist_ok=True, parents=True)
+CTX_PATH = f'{MLAD_HOME_PATH}/config.yml'
 Config = omegaconf.Container
 Context = omegaconf.Container
 StrDict = Dict[str, str]
 
 boilerplate = {
-    'current': None,
+    'current-context': None,
     'contexts': []
 }
 
@@ -104,8 +101,8 @@ def add(name: str, address: str, allow_duplicate=False) -> Context:
         config.contexts[duplicated_index] = context
     else:
         config.contexts.append(context)
-    if config.current is None:
-        config.current = name
+    if config['current-context'] is None:
+        config['current-context'] = name
 
     _save(config)
 
@@ -123,17 +120,17 @@ def use(name: str) -> Context:
     if context is None:
         raise NotExistContextError(name)
 
-    config.current = name
+    config['current-context'] = name
     _save(config)
     return context
 
 
 def _switch(direction: int = 1) -> str:
     config = _load()
-    if config.current is None:
+    if config['current-context'] is None:
         raise NotExistContextError('Any Contexts')
     n_contexts = len(config.contexts)
-    index = _find_context(config.current, config=config, index=True)
+    index = _find_context(config['current-context'], config=config, index=True)
     next_index = (index + direction) % n_contexts
     name = config.contexts[next_index].name
     use(name)
@@ -153,7 +150,7 @@ def delete(name: str) -> None:
     index = _find_context(name, config=config, index=True)
     if index is None:
         raise NotExistContextError(name)
-    elif config.current == config.contexts[index].name:
+    elif config['current-context'] == config.contexts[index].name:
         raise CannotDeleteContextError
     else:
         del config.contexts[index]
@@ -163,7 +160,7 @@ def delete(name: str) -> None:
 def get(name: Optional[str] = None) -> Context:
     config = _load()
     if name is None:
-        name = config.current
+        name = config['current-context']
 
     context = _find_context(name, config=config)
     if context is None:
@@ -194,7 +191,7 @@ def ls():
     names = [context.name for context in config.contexts]
     table = [('  NAME',)]
     for name in names:
-        table.append([f'  {name}' if config.current != name else f'* {name}'])
+        table.append([f'  {name}' if config['current-context'] != name else f'* {name}'])
     utils.print_table(table, 'There are no contexts.', 0)
 
 

--- a/python/mlad/cli/image.py
+++ b/python/mlad/cli/image.py
@@ -65,7 +65,7 @@ def build(quiet, plugin, no_cache, pull):
     # Generate Base Labels
     base_labels = core_utils.base_labels(
         utils.get_workspace(), 
-        config.mlad.session,
+        config.session,
         manifest[manifest_type], 
         manifest_type
     )
@@ -190,11 +190,12 @@ def search(keyword):
     config = config_core.get()
     try:
         images = []
-        catalog = json.loads(requests.get(f"http://{config['docker']['registry']}/v2/_catalog", verify=False).text)
+        registry_address = config.docker.registry.address
+        catalog = json.loads(requests.get(f"http://{registry_address}/v2/_catalog", verify=False).text)
         if 'repositories' in catalog:
             repositories = catalog['repositories']
             for repository in repositories:
-                tags = json.loads(requests.get(f'http://{config["docker"]["registry"]}/v2/{repository}/tags/list', verify=False).text)
+                tags = json.loads(requests.get(f'http://{registry_address}/v2/{repository}/tags/list', verify=False).text)
                 images += [ f"{config['docker']['registry']}/{tags['name']}:{tag}" for tag in tags['tags'] ] 
             found = [ item for item in filter(None, [image if keyword in image else None for image in images]) ]
 

--- a/python/mlad/cli/image.py
+++ b/python/mlad/cli/image.py
@@ -12,6 +12,7 @@ from mlad.core.default import project as default_project
 from mlad.core.default import plugin as default_plugin
 from mlad.core.docker import controller as ctlr
 from mlad.core.libs import utils as core_utils
+from mlad.cli import config as config_core
 from mlad.cli.libs import utils
 from mlad.cli.libs import interrupt_handler
 from mlad.cli.Format import PROJECT
@@ -54,7 +55,7 @@ def list(all, plugin, tail, no_trunc):
         print(f'This project has {untagged} untagged images. To free disk spaces up by cleaning gabage images.') 
 
 def build(quiet, plugin, no_cache, pull):
-    config = utils.read_config()
+    config = config_core.get()
     cli = ctlr.get_api_client()
     
     manifest_type = 'plugin' if plugin else 'project'
@@ -186,7 +187,7 @@ def build(quiet, plugin, no_cache, pull):
 
 def search(keyword):
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    config = utils.read_config()
+    config = config_core.get()
     try:
         images = []
         catalog = json.loads(requests.get(f"http://{config['docker']['registry']}/v2/_catalog", verify=False).text)
@@ -238,4 +239,3 @@ def prune(all):
         print(f'{reclaimed:.2f}{unit_list[unit]} Space Reclaimed.')
     else:
         print('Already cleared.', file=sys.stderr)
-

--- a/python/mlad/cli/libs/utils.py
+++ b/python/mlad/cli/libs/utils.py
@@ -25,24 +25,15 @@ HOME = str(Path.home())
 CONFIG_PATH = f'{Path.home()}/.mlad'
 CONFIG_FILE = f'{CONFIG_PATH}/config.yml'
 COMPLETION_FILE = f'{CONFIG_PATH}/completion.sh'
-PROJECT_FILE_ENV_KEY='MLAD_PRJFILE'
+PROJECT_FILE_ENV_KEY = 'MLAD_PRJFILE'
 DEFAULT_PROJECT_FILE = 'mlad-project.yml'
 DEFAULT_PLUGIN_FILE = 'mlad-plugin.yml'
-
-
-def generate_empty_config():
-    if not os.path.exists(CONFIG_PATH):
-        os.makedirs(CONFIG_PATH, exist_ok=True)
-    if not os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, 'w') as f:
-            f.write('')
 
 
 def create_session_key():
     user = getuser()
     hostname = socket.gethostname()
-    admin = auth_admin()
-    payload = {"user":user, "hostname": hostname, "uuid": str(uuid.uuid4())}
+    payload = {"user": user, "hostname": hostname, "uuid": str(uuid.uuid4())}
     encode = jwt.encode(payload, "mlad", algorithm="HS256")
     return encode
 
@@ -59,10 +50,6 @@ def project_key(workspace):
     return hash(workspace).hex
 
 
-def has_config():
-    return os.path.exists(CONFIG_FILE)
-
-
 def read_config():
     try:
         return OmegaConf.load(CONFIG_FILE)
@@ -71,9 +58,6 @@ def read_config():
               file=sys.stderr)
         sys.exit(1)
 
-
-def write_config(config):
-    OmegaConf.save(config=config, f=CONFIG_FILE)
 
 
 def get_completion(shell='bash'):
@@ -344,5 +328,3 @@ def get_username(session):
         return decoded["user"]
     else:
         raise RuntimeError("Session key is invalid.")
-
-

--- a/python/mlad/cli/node.py
+++ b/python/mlad/cli/node.py
@@ -9,7 +9,7 @@ from mlad.core.kubernetes import controller as ctlr
 
 def list(no_trunc):
     config = config_core.get()
-    api = API(config.mlad.address, config.mlad.session)
+    api = API(config.apiserver.address, config.session)
     try:
         nodes = [api.node.inspect(_) for _ in api.node.get()]
     except APIError as e:
@@ -83,7 +83,7 @@ def label_rm(node, *keys):
 
 def resource(nodes, no_trunc):
     config = config_core.get()
-    api = API(config.mlad.address, config.mlad.session)
+    api = API(config.apiserver.address, config.session)
     try:
         res = api.node.resource(nodes)
     except APIError as e:

--- a/python/mlad/cli/project.py
+++ b/python/mlad/cli/project.py
@@ -85,7 +85,7 @@ def init(name, version, maintainer):
 def list(no_trunc):
     config = config_core.get()
     projects = {}
-    api = API(config.mlad.address, config.mlad.session)
+    api = API(config.apiserver.address, config.session)
     try:
         networks = api.project.get()
     except APIError as e:
@@ -145,7 +145,7 @@ def list(no_trunc):
 
 def status(all, no_trunc):
     config = config_core.get()
-    api = API(config.mlad.address, config.mlad.session)
+    api = API(config.apiserver.address, config.session)
     project_key = utils.project_key(utils.get_workspace())
     # Block not running.
     try:
@@ -224,7 +224,8 @@ def status(all, no_trunc):
 def run(with_build):
     project = utils.get_project(default_project)
 
-    if with_build: build(False, True)
+    if with_build:
+        build(False, True)
 
     print('Deploying test container image to local...')
     config = config_core.get()
@@ -232,7 +233,7 @@ def run(with_build):
     cli = ctlr.get_api_client()
     base_labels = core_utils.base_labels(
             utils.get_workspace(), 
-            config.mlad.session,
+            config.session,
             project['project'])
     project_key = base_labels['MLAD.PROJECT']
     
@@ -286,7 +287,7 @@ def run(with_build):
 def up(services):
     config = config_core.get()
     cli = ctlr.get_api_client()
-    api = API(config.mlad.address, config.mlad.session)
+    api = API(config.apiserver.address, config.session)
     project = utils.get_project(default_project)
 
     base_labels = core_utils.base_labels(
@@ -417,7 +418,7 @@ def down(services, no_dump):
     project_key = utils.project_key(utils.get_workspace())
     workdir = utils.get_project(default_project)['project']['workdir']
 
-    api = API(config.mlad.address, config.mlad.session)
+    api = API(config.apiserver.address, config.session)
     # Block duplicated running.
     try:
         inspect = api.project.inspect(project_key=project_key)
@@ -609,7 +610,7 @@ def down_force(services, no_dump):
 def logs(tail, follow, timestamps, names_or_ids):
     config = config_core.get()
     project_key = utils.project_key(utils.get_workspace())
-    api = API(config.mlad.address, config.mlad.session)
+    api = API(config.apiserver.address, config.session)
     # Block not running.
     try:
         project = api.project.inspect(project_key)
@@ -633,7 +634,7 @@ def logs(tail, follow, timestamps, names_or_ids):
 def scale(scales):
     scale_spec = dict([ scale.split('=') for scale in scales ])
     config = config_core.get()
-    api = API(config.mlad.address, config.mlad.session)
+    api = API(config.apiserver.address, config.session)
     project_key = utils.project_key(utils.get_workspace())
     try:    
         project = api.project.inspect(project_key)

--- a/python/mlad/core/default/config.py
+++ b/python/mlad/core/default/config.py
@@ -4,20 +4,6 @@ import uuid
 from distutils.util import strtobool
 from omegaconf import OmegaConf
 
-client_config = {
-    'mlad': {
-        'address': 'http://localhost:8440',
-        'session': ''
-    },
-    'docker': {
-        'registry': {
-            'address': 'https://docker.io',
-            'namespace': ''
-        }
-    },
-    'datastore': {
-    }
-}
 
 service_config = {
     'docker': {
@@ -42,6 +28,5 @@ service_config = {
 }
 
 sys.modules[__name__] = {
-    'client': lambda x: OmegaConf.merge(OmegaConf.create(client_config), x),
     'service': lambda x: OmegaConf.merge(OmegaConf.create(service_config), x),
 }

--- a/python/mlad/service/__main__.py
+++ b/python/mlad/service/__main__.py
@@ -3,12 +3,11 @@ import uvicorn
 from mlad import __version__
 from mlad.service.libs import utils
 
-from fastapi import FastAPI, Depends, Header
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.logger import logger
-from mlad.service.routers import image, service, project, node, auth
-from mlad.service.auth import Authorization
+from mlad.service.routers import service, project, node
 from mlad.service.libs.auth import generate_admin_token
+from mlad.core.default.config import service_config
 
 '''
 # 인증 (Admin 전용)
@@ -80,16 +79,16 @@ def create_app():
     app.include_router(project.router, prefix=APIV1)
 
     print(f"Admin Token  : {generate_admin_token().decode()}")
-    print(f"Orchestrator : 'Kubernetes'")
-    print(f"Debug        : {'TRUE' if utils.is_debug_mode() else 'FALSE'}") 
+    print("Orchestrator : 'Kubernetes'")
+    print(f"Debug        : {'TRUE' if utils.is_debug_mode() else 'FALSE'}")
     print(f'Prefix       : {root_path}')
     return app
 
+
 app = create_app()
 
-#Run by 'python -m mlad.service'
+
 if __name__ == '__main__':
-    config = utils.read_config()
-    uvicorn.run(app, host=config['server']['host'],
-                port=config['server']['port'],
-                debug=config['server']['debug'])
+    uvicorn.run(app, host=service_config['host'],
+                port=service_config['port'],
+                debug=service_config['debug'])

--- a/python/mlad/service/libs/auth.py
+++ b/python/mlad/service/libs/auth.py
@@ -9,6 +9,7 @@ import psutil
 from mlad.service import exception
 from mlad.service.libs import utils
 
+
 # #Token
 # Admin: 
 #  admin:{created_date}

--- a/python/mlad/service/libs/utils.py
+++ b/python/mlad/service/libs/utils.py
@@ -1,24 +1,25 @@
 import sys
 import os
-from omegaconf import OmegaConf
-from functools import lru_cache
 from mlad.core.default import config as default_config
+from mlad.cli import config as config_core
 
 CONFIG_FILE = os.environ.get('MLAD_CONFIG_PATH', '/config.yaml')
 
-@lru_cache(maxsize=None)
+
 def read_config():
     try:
-        config = OmegaConf.load(CONFIG_FILE)
-    except FileNotFoundError as e:
+        config = config_core.get()
+    except Exception:
         config = {}
     return default_config['service'](config)
+
 
 def is_debug_mode():
     config = read_config()
     if '-d' in sys.argv or '--debug' in sys.argv or os.environ.get('MLAD_DEBUG', config['mlad']['debug']):
         return True
     return False
+
 
 def is_kube_mode():
     config = read_config()

--- a/python/tests/config/mock.py
+++ b/python/tests/config/mock.py
@@ -1,0 +1,41 @@
+import sys
+import io
+import shutil
+
+from mlad.cli import config, context
+from pathlib import Path
+from omegaconf import OmegaConf
+
+origin_stdin = None
+
+
+def setup():
+    context.CTX_PATH = './tests/context.yml'
+    Path('./tests').mkdir(exist_ok=True, parents=True)
+    OmegaConf.save(config=context.boilerplate, f=context.CTX_PATH)
+    global origin_stdin
+    origin_stdin = sys.stdin
+
+
+def teardown():
+    context.CTX_PATH = f'{context.MLAD_HOME_PATH}/context.yml'
+    shutil.rmtree('./tests')
+    global origin_stdin
+    sys.stdin = origin_stdin
+
+
+def init():
+    inputs = [
+        'https://ncml-dev.cloud.ncsoft.com',
+        'https://harbor.sailio.ncsoft.com',
+        'gameai',
+        'https://localhost:9000',
+        'us-west-1',
+        'minioadmin',
+        'minioadmin',
+        'mongodb://localhost:27017',
+        'dbadmin',
+        'dbadmin'
+    ]
+    sys.stdin = io.StringIO(''.join([f'{_}\n' for _ in inputs[1:]]))
+    return config.init(inputs[0])

--- a/python/tests/config/test_env.py
+++ b/python/tests/config/test_env.py
@@ -1,0 +1,45 @@
+from mlad.cli import config
+
+from . import mock
+
+
+def setup_function():
+    mock.setup()
+
+
+def teardown_function():
+    mock.teardown()
+
+
+def test_env():
+    mock.init()
+    ret, _ = config.env(unset=False)
+    expected = sorted([
+        'export S3_ENDPOINT=https://localhost:9000',
+        'export S3_USE_HTTPS=1',
+        'export S3_VERIFY_SSL=0',
+        'export AWS_ACCESS_KEY_ID=minioadmin',
+        'export AWS_SECRET_ACCESS_KEY=minioadmin',
+        'export AWS_REGION=us-west-1',
+        'export DB_ADDRESS=mongodb://localhost:27017',
+        'export DB_USERNAME=dbadmin',
+        'export DB_PASSWORD=dbadmin'
+    ])
+    assert ret == expected
+
+
+def test_env_unset():
+    mock.init()
+    ret, _ = config.env(unset=True)
+    expected = sorted([
+        'export S3_ENDPOINT=',
+        'export S3_USE_HTTPS=',
+        'export S3_VERIFY_SSL=',
+        'export AWS_ACCESS_KEY_ID=',
+        'export AWS_SECRET_ACCESS_KEY=',
+        'export AWS_REGION=',
+        'export DB_ADDRESS=',
+        'export DB_USERNAME=',
+        'export DB_PASSWORD='
+    ])
+    assert ret == expected

--- a/python/tests/config/test_init.py
+++ b/python/tests/config/test_init.py
@@ -1,0 +1,17 @@
+from mlad.cli import context
+
+from . import mock
+
+
+def setup_function():
+    mock.setup()
+
+
+def teardown_function():
+    mock.teardown()
+
+
+def test_init():
+    mock.init()
+    config = context._load()
+    assert config.current == 'default'

--- a/python/tests/config/test_init.py
+++ b/python/tests/config/test_init.py
@@ -14,4 +14,4 @@ def teardown_function():
 def test_init():
     mock.init()
     config = context._load()
-    assert config.current == 'default'
+    assert config['current-context'] == 'default'

--- a/python/tests/context/mock.py
+++ b/python/tests/context/mock.py
@@ -10,7 +10,7 @@ origin_stdin = None
 
 
 def setup():
-    context.CTX_PATH = './tests/context.yml'
+    context.CTX_PATH = './tests/config.yml'
     Path('./tests').mkdir(exist_ok=True, parents=True)
     OmegaConf.save(config=context.boilerplate, f=context.CTX_PATH)
     global origin_stdin
@@ -18,7 +18,7 @@ def setup():
 
 
 def teardown():
-    context.CTX_PATH = f'{context.MLAD_HOME_PATH}/context.yml'
+    context.CTX_PATH = f'{context.MLAD_HOME_PATH}/config.yml'
     shutil.rmtree('./tests')
     global origin_stdin
     sys.stdin = origin_stdin

--- a/python/tests/context/test_add.py
+++ b/python/tests/context/test_add.py
@@ -171,6 +171,8 @@ def test_allow_duplicate():
             }
         }
     }
-    context_dict = OmegaConf.to_object(context.add('test-allow-duplicate', inputs[0], allow_duplicate=True))
+    context_dict = OmegaConf.to_object(
+        context.add('test-allow-duplicate', inputs[0], allow_duplicate=True)
+    )
     del context_dict['session']
     assert expected == context_dict

--- a/python/tests/context/test_add.py
+++ b/python/tests/context/test_add.py
@@ -51,8 +51,9 @@ def test_valid_input():
             }
         }
     }
-    assert expected == OmegaConf.to_object(context.add('test-valid', inputs[0]))
-    assert expected == context._find_context('test-valid')
+    context_dict = OmegaConf.to_object(context.add('test-valid', inputs[0]))
+    del context_dict['session']
+    assert context_dict == expected
 
 
 def test_valid_input2():
@@ -88,8 +89,9 @@ def test_valid_input2():
             }
         }
     }
-    assert expected == OmegaConf.to_object(context.add('test-valid2', inputs[0]))
-    assert expected == context._find_context('test-valid2')
+    context_dict = OmegaConf.to_object(context.add('test-valid2', inputs[0]))
+    del context_dict['session']
+    expected == context_dict
 
 
 def test_invalid_input():
@@ -132,3 +134,43 @@ def test_dupilicate():
     mock.add('test')
     with pytest.raises(ContextAlreadyExistError):
         mock.add('test')
+
+
+def test_allow_duplicate():
+    mock.add('test-allow-duplicate')
+    inputs = [
+        'https://ncml-dev.cloud.ncsoft.com',
+        'Y',
+        'https://harbor.sailio.ncsoft.com',
+        '',
+        'http://localhost:9000',
+        'us-west-1',
+        'minioadmin',
+        'minioadmin',
+        'mongodb://localhost:27017',
+        '',
+        ''
+    ]
+    sys.stdin = io.StringIO(''.join([f'{_}\n' for _ in inputs[1:]]))
+    expected = {
+        'name': 'test-allow-duplicate',
+        'apiserver': {'address': inputs[0]},
+        'docker': {'registry': {'address': inputs[2], 'namespace': None}},
+        'datastore': {
+            's3': {
+                'endpoint': inputs[4],
+                'region': inputs[5],
+                'accesskey': inputs[6],
+                'secretkey': inputs[7],
+                'verify': False
+            },
+            'db': {
+                'address': inputs[8],
+                'username': None,
+                'password': None
+            }
+        }
+    }
+    context_dict = OmegaConf.to_object(context.add('test-allow-duplicate', inputs[0], allow_duplicate=True))
+    del context_dict['session']
+    assert expected == context_dict

--- a/python/tests/context/test_set.py
+++ b/python/tests/context/test_set.py
@@ -44,8 +44,9 @@ def test_set():
             }
         }
     }
-    ctx = context.get('test1')
-    assert expected == OmegaConf.to_object(ctx)
+    context_dict = OmegaConf.to_object(context.get('test1'))
+    del context_dict['session']
+    assert expected == context_dict
 
 
 def test_invalid_set():

--- a/python/tests/context/test_switch.py
+++ b/python/tests/context/test_switch.py
@@ -20,22 +20,22 @@ def test_next():
     for index in range(5):
         mock.add(f'next-{index}')
     config = context._load()
-    assert config.current == 'next-0'
+    assert config['current-context'] == 'next-0'
     for index in range(5):
         context.next()
         config = context._load()
-        config.current == f'next-{(index + 1) % 5}'
+        config['current-context'] == f'next-{(index + 1) % 5}'
 
 
 def test_prev():
     for index in range(5):
         mock.add(f'prev-{index}')
     config = context._load()
-    assert config.current == 'prev-0'
+    assert config['current-context'] == 'prev-0'
     for index in range(5):
         context.next()
         config = context._load()
-        config.current == f'prev-{(5 - index) % 5}'
+        config['current-context'] == f'prev-{(5 - index) % 5}'
 
 
 def test_invalid_use():

--- a/python/tests/context/test_use.py
+++ b/python/tests/context/test_use.py
@@ -20,7 +20,7 @@ def test_use():
     mock.add('use')
     context.use('use')
     config = context._load()
-    assert config.current == 'use'
+    assert config['current-context'] == 'use'
 
 
 def test_invalid_use():


### PR DESCRIPTION
Resolves #43 

config가 context 기능을 사용하도록 하면서
`default.config`의 일부와 `datastore`를 더 이상 사용하지 않도록 바꿨습니다.
위와 같이 바꾸고 나니 `config.py`의 위치가 `cli`인게 어색해서 후에 리펙토링이 필요한 것 같습니다.
project쪽 업데이트되고나서 안쓰는 코드는 한 번에 정리하려고 합니다.

**추가 변경사항**
* `context.yml`에서 `config.yml`에 저장되도록 변경하였습니다.
* `apiserver.address` 등으로 최대한 바꿨습니다.