### PR TITLE
Delete the export logic to allow other module can import the service_config

### DIFF
--- a/python/mlad/core/default/config.py
+++ b/python/mlad/core/default/config.py
@@ -26,7 +26,3 @@ service_config = {
         'user': str(uuid.uuid4()),
     },
 }
-
-sys.modules[__name__] = {
-    'service': lambda x: OmegaConf.merge(OmegaConf.create(service_config), x),
-}


### PR DESCRIPTION
`default/config`쪽에 export 로직 때문에 service_config를 제대로 로드하지 못하는 문제가 있어 수정 후 PR 보냅니다.