### PR TITLE
Refactor node relevant logics

### DIFF
--- a/python/mlad/api/node.py
+++ b/python/mlad/api/node.py
@@ -1,29 +1,19 @@
 import requests
 from .exception import raise_error
 
+
 class Node:
     def __init__(self, url, session):
-        self.url = url   
-        self.session = session
+        self.url = url
+        self.headers = {'session': session}
 
-    def get(self):
-        url = f'{self.url}/node'
-        header = {'session':self.session}
-        res = requests.get(url=url, headers=header)
+    def list(self):
+        res = requests.get(url=f'{self.url}/node/list', headers=self.headers)
         raise_error(res)
         return res.json()
 
-    def inspect(self, node_id):
-        url = f'{self.url}/node/{node_id}'
-        header = {'session':self.session}
-        res = requests.get(url=url, headers=header)
-        raise_error(res)
-        return res.json()
-
-    def resource(self, nodes=[]):
-        url = f'{self.url}/nodes/resource'
-        header = {'session': self.session}
-        params = {'nodes': nodes}
-        res = requests.get(url=url, params=params, headers=header)
+    def resource(self, names):
+        res = requests.get(url=f'{self.url}/node/resource', headers=self.headers,
+                           params={'names': names})
         raise_error(res)
         return res.json()

--- a/python/mlad/cli/node_cli.py
+++ b/python/mlad/cli/node_cli.py
@@ -42,11 +42,11 @@ def rm(id, key):
 
 
 @click.command()
-@click.argument('nodes', nargs=-1, required=False)
+@click.argument('NAMES', nargs=-1, required=False)
 @click.option('--no-trunc', is_flag=True, help='Don\'t truncate output')
-def resource(nodes, no_trunc):
+def resource(names, no_trunc):
     '''Show resource status of nodes'''
-    node.resource(nodes, no_trunc)
+    node.resource(names=names, no_trunc=no_trunc)
 
 
 @click.group()

--- a/python/mlad/core/kubernetes/controller.py
+++ b/python/mlad/core/kubernetes/controller.py
@@ -821,29 +821,15 @@ def prune_images(cli, project_key=None):
 
 def push_images(cli, project_key, stream=False):
     return docker_controller.push_images(docker.from_env(), project_key, stream)
- 
 
-def get_nodes(cli = DEFAULT_CLI):
+
+def get_nodes(cli=DEFAULT_CLI):
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
 
     api = client.CoreV1Api(cli)
-    return dict(
-        [(_.metadata.name, _.metadata) for _ in api.list_node().items]
-    )
+    return {node.metadata.name: node for node in api.list_node().items}
 
-
-def get_node(node_key, cli = DEFAULT_CLI):
-    if not isinstance(cli, client.api_client.ApiClient):
-        raise TypeError('Parameter is not valid type.')
-
-    api = client.CoreV1Api(cli)
-    nodes = api.list_node(field_selector=f"metadata.name={node_key}")
-    if nodes.items: 
-        return nodes.items[0]
-    else:
-        #print(f'Cannot find node "{node_key}"', file=sys.stderr)
-        raise exceptions.NotFound(f'Cannot find node "{node_key}"')
 
 def inspect_node(node):
     if not isinstance(node, client.models.v1_node.V1Node):
@@ -1123,10 +1109,11 @@ def get_node_resources(node, cli = None):
     if cli is None :
         cli = DEFAULT_CLI
     else:
-        if not isinstance(cli, client.api_client.ApiClient): raise \
-            TypeError('Parameter is not valid type.')
-
-    if not isinstance(node, client.models.v1_node.V1Node): raise TypeError('Parameter is not valid type.')
+        if not isinstance(cli, client.api_client.ApiClient):
+            raise TypeError('Parameter is not valid type.')
+    print(node)
+    if not isinstance(node, client.models.v1_node.V1Node):
+        raise TypeError('Parameter is not valid type.')
 
     api = client.CustomObjectsApi(cli)
     v1_api = client.CoreV1Api(cli)

--- a/python/mlad/core/kubernetes/controller.py
+++ b/python/mlad/core/kubernetes/controller.py
@@ -5,8 +5,6 @@ import json
 import uuid
 from collections import defaultdict
 import docker
-from kubernetes.client import models
-import requests
 from mlad.core import exceptions
 from mlad.core.exceptions import NetworkAlreadyExistError
 from mlad.core.libs import utils
@@ -1108,10 +1106,9 @@ def parse_cpu(str_cpu):
 def get_node_resources(node, cli = None):
     if cli is None :
         cli = DEFAULT_CLI
-    else:
-        if not isinstance(cli, client.api_client.ApiClient):
-            raise TypeError('Parameter is not valid type.')
-    print(node)
+    elif not isinstance(cli, client.api_client.ApiClient):
+        raise TypeError('Parameter is not valid type.')
+    
     if not isinstance(node, client.models.v1_node.V1Node):
         raise TypeError('Parameter is not valid type.')
 

--- a/python/mlad/service/libs/utils.py
+++ b/python/mlad/service/libs/utils.py
@@ -1,6 +1,6 @@
 import sys
 import os
-from mlad.core.default import config as service_config
+from mlad.core.default.config import service_config
 from mlad.cli import config as config_core
 
 

--- a/python/mlad/service/routers/node.py
+++ b/python/mlad/service/routers/node.py
@@ -1,11 +1,8 @@
 from typing import List
 from fastapi import APIRouter, Query, Header, HTTPException
-from mlad.service.models import node
 from mlad.core import exceptions
-from requests.exceptions import HTTPError
 from mlad.service.exception import exception_detail
 from mlad.service.libs.log import init_logger
-from mlad.service.libs import utils
 from mlad.core.kubernetes import controller as ctlr
 
 
@@ -13,45 +10,30 @@ router = APIRouter()
 logger = init_logger(__name__)
 
 
-@router.get("/node")
+@router.get("/node/list")
 def node_list(session: str = Header(None)):
     try:
         nodes = ctlr.get_nodes()
+        return [ctlr.inspect_node(node) for node in nodes.values()]
     except Exception as e:
         logger.error(e)
         raise HTTPException(status_code=500, detail=exception_detail(e))
-    return list(nodes.keys())
 
 
-@router.get("/node/{node_id}")
-def node_inspect(node_id:str, session: str = Header(None)):
+@router.get("/node/resource")
+def node_resource(names: List[str] = Query(None)):
+    res = {}
     try:
-        node = ctlr.get_node(node_id)
-        inspects = ctlr.inspect_node(node)
-    except exception.NotFound as e:
-        logger.error(e)
-        raise HTTPException(status_code=404, detail=exception_detail(e))
-    except Exception as e:
-        logger.error(e)
-        raise HTTPException(status_code=500, detail=exception_detail(e))
-    return inspects
-
-
-@router.get("/nodes/resource")
-def node_resource(nodes: List[str] = Query(None)):
-    res={}
-    try:
-        if not nodes:
-            nodes = ctlr.get_nodes()
-        for node in nodes:
-            node = ctlr.get_node(node)
-            name = node.metadata.name
+        nodes = ctlr.get_nodes()
+        if names is not None and len(names) > 0:
+            nodes = [node for node in nodes if node.metadata.name in names]
+        for node in nodes.values():
             resource = ctlr.get_node_resources(node)
-            res[name] = resource
-    except exception.NotFound as e:
+            res[node.metadata.name] = resource
+        return res
+    except exceptions.NotFound as e:
         logger.error(e)
         raise HTTPException(status_code=400, detail=exception_detail(e))
     except Exception as e:
         logger.error(e)
         raise HTTPException(status_code=500, detail=exception_detail(e))
-    return res


### PR DESCRIPTION
Resolves #50 

* node api 코드 정리했습니다
* node 정보를 가져올 때 한 번에 inspect 정보까지 가져오도록 바꿨습니다.
* `resource` 에서 print 포멧을 개선했습니다
* router 및 controller의 데이터 포멧 및 로직을 수정했습니다
* 진짜 node를 가리키는 `node`인지 해당 node의 이름인지 모호한 부분의 변수명을 수정했습니다.