### PR TITLE
Feature/issue-49 : Modify project & service modules based on reformed schema

### DIFF
--- a/examples/project/mlad-project.yml
+++ b/examples/project/mlad-project.yml
@@ -1,69 +1,35 @@
-# MLAppDeploy Project v0.1
-project:
-    name: example
-    version: 0.0.1
-    maintainer: onetop21
+# MLAppDeploy Project v0.3
+apiVersion: v1                     # Describe api version. (*v1)
+maintainer: root                   # Describe maintainer. (*env.USER)
+name: example                      # Describe project name.
+version: 0.0.1                     # Describe verison. (*1.0.0)
+workdir: .
+ingress:                           # [OPTIONAL] Describe ingress to expose.
+    test-ingress:
+        rewritePath: true
+        target: server:1234
 workspace:
-    ## Describe base docker image tag
-    base: python:latest
-    ## Describe package manager and dependency list to install pre-required.
-    requires:
-        pip: requirements.txt
-    ## Describe environment variables.
-    #env:  
-    #    PYTHONUNBUFFERED: 1    
-    ## Describe exclude files from project.
-    ignore:
-       - "**/.*"
-       - "test"
-       - "*.tar"
-    ## Describe Pre/Post scripts for preparing.
-    #prescripts: []
-    #postscripts: []
-    ## Describe application to execute
-    #command: python run.py
-    ## Describe arguments for execute application
-    #arguments: --help
-services:
+    kind: Workspace                # Describe kind of workspace. (*Workspace, Dockerfile)
+    base: python:latest            # Describe base docker image tag.
+    preps:
+      - pip: requirements.txt      # [OPTIONAL] Describe prepare options for run.
+app:
     server:
-        ports: [5555]
-        command: python server.py
+        kind: App                  # [OPTIONAL] Describe kind of app. (*App, Job, Service)
+        command: python server.py  # [OPTIONAL] Describe command to need overwrite.
+        ports: [5555]              # [OPTIONAL] Describe expose ports to other apps.
     client:
+        kind: App
         command: python client.py
-        deploy:
-            replicas: 1
-            restart_policy:
-                condition: always
-    test:
-        command: python client.py
-        env:
-            test: 123 
-#        deploy:
-#            replicas: 1
-            # constraints:
-            #     labels.type: master
-    #[SERVICENAME]:
-    ## Describe image to run docker service for run not built image from workspace.
-    #    image: 
-    ## Describe environment variables additionaly.
-    #    env:
-    #        [KEY]: [VALUE]
-    ## Describe services before running current service.
-    #    depends: [ SERVICENAME, ... ]
-    ## Describe command to need overwrite.
-    #    command:
-    ## Describe arguments to need overwrite.
-    #    arguments:
-    #
-    ## Deploy only options
-    #    deploy:
-    ## Describe required system resource quote.
-    #        quota:
-    #            cpus: 1
-    #            mems: 8G
-    #            gpus: 0
-    ## Describe target node to run services.
-    #        constraints:
-    ## Describe number to run service instances.
-    #        replicas: 1
-    #...
+        constraints:               # [OPTIONAL] Describe target node to run app.
+            hostname: docker-desktop
+        ports: [5555]
+#        env:
+#            test: test-env
+#        scale: 1                   # [OPTIONAL] Describe number of replicas or parallelism. (*1)
+#        quota:                     # [OPTIONAL] Describe required system resource q
+#            cpu: 1
+#            gpu: 0
+#        restartPolicy: never       # [OPTIONAL] Describe restart policy. (*never, on-failure, always)
+
+

--- a/python/mlad/api/project.py
+++ b/python/mlad/api/project.py
@@ -17,12 +17,11 @@ class Project:
         raise_error(res)
         return res.json()    
 
-    def create(self, project, base_labels, extra_envs=[], credential=None, allow_reuse=False):
+    def create(self, base_labels, extra_envs=[], credential=None, allow_reuse=False):
         url = self.url
         header = {'session': self.session}
         resp = requests.post(url=url,headers=header,
-            json={'project':project,'base_labels':base_labels,
-                'extra_envs':extra_envs, 'credential':credential},
+            json={'base_labels':base_labels, 'extra_envs':extra_envs, 'credential':credential},
             params={'allow_reuse': allow_reuse}, stream=True)
         if resp.status_code == 200:
             res = ''

--- a/python/mlad/cli/Format/PROJECT.py
+++ b/python/mlad/cli/Format/PROJECT.py
@@ -46,21 +46,22 @@ app:
     #        [KEY]: [VALUE]         # [OPTIONAL] Describe environment variables additionaly.
     #    ports: [80,...]            # [OPTIONAL] Describe expose ports to other apps.
     #    args: temp                 # [OPTIONAL] Describe arguments to need overwrite.
-    #    mounts: ['test-mnt:/data'] # [OPTIONAL] Describe mounts.
+    #    mounts:                    # [OPTIONAL] Describe mounts.
+    #       - '/host-path:/mnt-path'
     #    scale: 1                   # [OPTIONAL] Describe number of replicas or parallelism. (*1)
     #    quota:                     # [OPTIONAL] Describe required system resource quota.
     #        cpu: 1
     #        gpu: 0
     #        mem: 8G
-    #    restartPolicy: never       # [OPTIONAL] Describe restart policy. (*never, on-failure, always)
+    #    restartPolicy: never       # [OPTIONAL] Describe restart policy. (*never, onFailure, always)
     ### Describe 'Job' to run.
     #[NAME]:
     ## Available fields from app - image, env, ports, command, args, mounts, constraints 
     #    kind: Job                  # [OPTIONAL] Describe kind of app. (*App, Job, Service)
     #    runSpec:                   # [OPTIONAL] Describe spec for running Job. 
-    #        restartPolicy: never   # [OPTIONAL] Describe restart policy. (*never, on-failure)
+    #        restartPolicy: never   # [OPTIONAL] Describe restart policy. (*never, onFailure)
     #        parallelism: 1         # [OPTIONAL] (*1)
-    #        Completion: 1          # [OPTIONAL] (*1)
+    #        completion: 1          # [OPTIONAL] (*1)
     #    resources:                 # [OPTIONAL] Describe resource specifically for the Job.
     #        limits:
     #            cpu: 1

--- a/python/mlad/cli/Format/PROJECT.py
+++ b/python/mlad/cli/Format/PROJECT.py
@@ -1,43 +1,87 @@
 import sys
 
-FORMAT='''# MLAppDeploy Project v0.2
-project:
-    name: {NAME}
-    version: {VERSION}
-    maintainer: {MAINTAINER}
-    #workdir: .                     # Describe workspace directory.
+
+FORMAT='''# MLAppDeploy Project v0.3
+apiVersion: v1                      # [OPTIONAL] Describe api version. (*v1)
+maintainer: {MAINTAINER}            # [OPTIONAL] Describe maintainer. (*env.USER)
+name: {NAME}                        # Describe project name.
+version: {VERSION}                  # [OPTIONAL] Describe verison. (*1.0.0)
+workdir: .                          # [OPTIONAL] Describe working directory. (*.)
+ingress:                            # [OPTIONAL] Describe ingress to expose.
+    #[NAME]:
+    #    rewritePath: true
+    #    target: SERVICENAME:8080  
 workspace:
-    #base: python:latest            # Describe base docker image tag
-    #requires:                      # Describe package manager and dependency list to install pre-required.
-    #    pip: requirements.txt
-    #env:                           # Describe environment variables.
-    #    PYTHONUNBUFFERED: 1        
-    #ignore:                        # Describe exclude files from project.
+    #kind: Workspace                # Describe kind of workspace. (*Workspace, Dockerfile)
+    #base: python:latest            # Describe base docker image tag.
+    #command: python test.py        # [OPTIONAL] Describe application to execute.
+    #args: temp                     # [OPTIONAL] Describe arguments for execute application.
+    #preps:                         # [OPTIONAL] Describe prepare options for run.
+    #   - pip: requirements.txt       
+    #env:                           # [OPTIONAL] Describe environment variables.
+    #    PYTHONUNBUFFERED: 1   
+    #ignore:                        # [OPTIONAL] Describe exclude files from project.
     #   - "**/.*"
-    #prescripts: []                 # Describe Pre-scripts for preparing.
-    #postscripts: []                # Describe Post-scripts for preparing.
-    #command: python run.py         # Describe application to execute
-    #arguments: --help              # Describe arguments for execute application
-services:
-    #[SERVICENAME]:
-    #    image:                     # Describe image to run docker service for run not built image from workspace.
-    #    env:                       # Describe environment variables additionaly.
-    #        [KEY]: [VALUE]
-    #    command:                   # Describe command to need overwrite.
-    #    arguments:                 # Describe arguments to need overwrite.
-    #    ports: [80,...]            # Describe expose ports to other services.
-    #    deploy:                    # Deploy only options
-    #        restart_policy: always # Describe restart policy. (never, on-failure, always)
-    #        quota:                 # Describe required system resource quota.
-    #            cpus: 1
-    #            mems: 8G
-    #            gpus: 0
-    #        constraints:           # Describe target node to run services.
-    #            hostname:
-    #            label:
-    #        replicas: 1            # Describe number to run service instances.
-    #...
+    #script: python script.py       # [OPTIONAL] Describe script for run.
+app:
+    ### Describe 'App' to run.
+    #[NAME]:
+    #    kind: App                  # [OPTIONAL] Describe kind of app. (*App, Job, Service)
+    #    image: mongo               # [OPTIONAL] Describe image to run app for run not built image from workspace.
+    #    command: python test.py    # [OPTIONAL] Describe command to need overwrite.
+    #    constraints:               # [OPTIONAL] Describe target node to run app.
+    #        hostname: node1
+    #        label:
+    #            [KEY]: [VALUE]
+    #    env:
+    #        [KEY]: [VALUE]         # [OPTIONAL] Describe environment variables additionaly.
+    #    ports: [80,...]            # [OPTIONAL] Describe expose ports to other apps.
+    #    args: temp                 # [OPTIONAL] Describe arguments to need overwrite.
+    #    mounts: ['test-mnt:/data'] # [OPTIONAL] Describe mounts.
+    #    scale: 1                   # [OPTIONAL] Describe number of replicas or parallelism. (*1)
+    #    quota:                     # [OPTIONAL] Describe required system resource quota.
+    #        cpu: 1
+    #        gpu: 0
+    #        mem: 8G
+    #    restartPolicy: never       # [OPTIONAL] Describe restart policy. (*never, on-failure, always)
+    ### Describe 'Job' to run.
+    #[NAME]:
+    ## Available fields from app - image, env, ports, command, args, mounts, constraints 
+    #    kind: Job                  # [OPTIONAL] Describe kind of app. (*App, Job, Service)
+    #    runSpec:                   # [OPTIONAL] Describe spec for running Job. 
+    #        restartPolicy: never   # [OPTIONAL] Describe restart policy. (*never, on-failure)
+    #        parallelism: 1         # [OPTIONAL] (*1)
+    #        Completion: 1          # [OPTIONAL] (*1)
+    #    resources:                 # [OPTIONAL] Describe resource specifically for the Job.
+    #        limits:
+    #            cpu: 1
+    #            gpu: 0
+    #            mem: 8G
+    #        requests:
+    #            cpu: 1
+    #            gpu: 0
+    #            mem: 8G
+    ### Describe 'Service' to run.
+    #[NAME]:
+    ## Available fields from app - image, env, ports, command, args, mounts, constraints 
+    #    kind: Service              # [OPTIONAL] Describe kind of app. (*App, Job, Service)
+    #    runSpec:                   # [OPTIONAL] Describe spec for running Service. 
+    #        replicas: 1
+    #        autoscaler:
+    #            enable: false
+    #            min: 1
+    #            max: 1
+    #            metrics:
+    #              - resources: cpu
+    #    resources:                 # [OPTIONAL] Describe resource for the Job
+    #        limits:
+    #            cpu: 1
+    #            gpu: 0
+    #            mem: 8G
+    #        requests:
+    #            cpu: 1
+    #            gpu: 0
+    #            mem: 8G   
 '''
 
 sys.modules[__name__] = FORMAT
-

--- a/python/mlad/cli/Format/PROJECT.py
+++ b/python/mlad/cli/Format/PROJECT.py
@@ -23,6 +23,15 @@ workspace:
     #ignore:                        # [OPTIONAL] Describe exclude files from project.
     #   - "**/.*"
     #script: python script.py       # [OPTIONAL] Describe script for run.
+    #-------------------------------#
+    #kind: Dockerfile               # Describe kind of workspace. (*Workspace, Dockerfile)
+    #script: |                      # Describe Dockerfile script.
+    #   FROM python:latest
+    #   RUN echo "hello world"
+    #ignores:                       # [OPTIONAL] Describe exclude files from project.
+    #   - "**/.*"
+    #filePath: .                    # Describe Dockerfile path. (Instead of defining script.)
+    #ignorePath: ./data             # [OPTIONAL] Describe exclude file path. (Instead of defining ignores)
 app:
     ### Describe 'App' to run.
     #[NAME]:

--- a/python/mlad/cli/context.py
+++ b/python/mlad/cli/context.py
@@ -24,6 +24,7 @@ boilerplate = {
 }
 
 if not os.path.isfile(CTX_PATH):
+    Path(MLAD_HOME_PATH).mkdir(exist_ok=True, parents=True)
     OmegaConf.save(config=boilerplate, f=CTX_PATH)
 
 

--- a/python/mlad/cli/image.py
+++ b/python/mlad/cli/image.py
@@ -62,13 +62,13 @@ def list(all, plugin, tail, no_trunc):
 
 
 def build(quiet: bool, no_cache: bool, pull: bool):
-    config = utils.read_config()
+    config = config_core.get()
     cli = ctlr.get_api_client()
     manifest = utils.get_manifest()
 
     # Generate Base Labels
     workspace_key = utils.get_workspace()
-    base_labels = core_utils.base_labels(workspace_key, config.mlad.session, manifest)
+    base_labels = core_utils.base_labels(workspace_key, config.session, manifest)
 
     # Prepare Latest Image
     latest_image = None

--- a/python/mlad/cli/libs/utils.py
+++ b/python/mlad/cli/libs/utils.py
@@ -111,17 +111,21 @@ def get_project(default_project):
 
     # replace workdir to abspath
     project_file = get_project_file()
-    project = default_project(project)
-    path = project['project'].get('workdir', './')
+    #project = default_project(project)
+    path = project.get('workdir', './')
     if not os.path.isabs(path):
-        project['project']['workdir'] = os.path.normpath(
+        project['workdir'] = os.path.normpath(
             os.path.join(
                 os.path.dirname(project_file),
                 path
             )
         )
-    if not check_podname_syntax(project['project']['name']) or \
-            not check_podname_syntax(project['services']):
+    # if not check_podname_syntax(project['name']) or \
+    #         not check_podname_syntax(project['services']):
+    #     print('Syntax Error: Project(Plugin) and service require a name to '
+    #           'follow standard as defined in RFC1123.', file=sys.stderr)
+    #     sys.exit(1)
+    if not check_podname_syntax(project['name']):
         print('Syntax Error: Project(Plugin) and service require a name to '
               'follow standard as defined in RFC1123.', file=sys.stderr)
         sys.exit(1)

--- a/python/mlad/cli/libs/utils.py
+++ b/python/mlad/cli/libs/utils.py
@@ -120,13 +120,8 @@ def get_project(default_project):
                 path
             )
         )
-    # if not check_podname_syntax(project['name']) or \
-    #         not check_podname_syntax(project['services']):
-    #     print('Syntax Error: Project(Plugin) and service require a name to '
-    #           'follow standard as defined in RFC1123.', file=sys.stderr)
-    #     sys.exit(1)
     if not check_podname_syntax(project['name']):
-        print('Syntax Error: Project(Plugin) and service require a name to '
+        print('Syntax Error: Project and service require a name to '
               'follow standard as defined in RFC1123.', file=sys.stderr)
         sys.exit(1)
     return project

--- a/python/mlad/cli/project.py
+++ b/python/mlad/cli/project.py
@@ -219,7 +219,7 @@ def status(all, no_trunc):
                     ))
         except NotFound as e:
             pass
-        columns += sorted([tuple(elem) for elem in task_info])
+        columns += sorted([tuple(elem) for elem in task_info], key=lambda x: x[1])
     username = utils.get_username(config.session)
     print(f"USERNAME: [{username}] / PROJECT: [{inspect['project']}]")
     utils.print_table(columns, 'Cannot find running services.', 0 if no_trunc else 32, False)
@@ -299,8 +299,6 @@ def run(no_build, env, quota, command):
         sys.exit(1)
     except StopIteration:
         pass
-
-    workspace, ingress = [project.pop(key, None) for key in ['workspace', 'ingress']]
 
     # AuthConfig
     cli = ctlr.get_api_client()
@@ -423,9 +421,8 @@ def up(service_names):
     else:
         targets = project['app'] or {}
 
-    workspace, ingress, app = [project.pop(key, None) for key in ['workspace', 'ingress', 'app']]
-
-    if ingress is not None:
+    if 'ingress' in project:
+        ingress = project['ingress']
         for name, _ in ingress.items():
             service, port = _['target'].split(':')
             if service in targets.keys():

--- a/python/mlad/cli/project_cli.py
+++ b/python/mlad/cli/project_cli.py
@@ -41,7 +41,7 @@ def ps(all, no_trunc):
     project.status(all, no_trunc)
 
 
-@click.command()
+@click.command(context_settings={"ignore_unknown_options": True})
 @click.option('--no-build', is_flag=True, help='Run without project build.')
 @click.option('--env', is_flag=True, help='Set all os envs for run')
 @click.option('--quota', type=click.STRING, multiple=True, help='Set quota for run')

--- a/python/mlad/cli/project_cli.py
+++ b/python/mlad/cli/project_cli.py
@@ -41,12 +41,14 @@ def ps(all, no_trunc):
     project.status(all, no_trunc)
 
 
-@click.command(context_settings={"ignore_unknown_options": True})
-@click.option('--build', '-b', is_flag=True, help='Build a project image before run')
-@click.argument('arguments', nargs=-1, required=False)
-def run(build, arguments):
-    '''Deploy and run a project instantly on cluster'''
-    project.run(build)
+@click.command()
+@click.option('--no-build', is_flag=True, help='Run without project build.')
+@click.option('--env', is_flag=True, help='Set all os envs for run')
+@click.option('--quota', type=click.STRING, multiple=True, help='Set quota for run')
+@click.argument('command', nargs=-1, required=True)
+def run(no_build, env, quota, command):
+    '''Run project with minimal options for app without definition'''
+    project.run(no_build, env, quota, command)
 
 
 @click.command()

--- a/python/mlad/cli/validator/exceptions.py
+++ b/python/mlad/cli/validator/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidProjectYaml(Exception):
+    pass

--- a/python/mlad/cli/validator/project_validator.py
+++ b/python/mlad/cli/validator/project_validator.py
@@ -1,7 +1,6 @@
 #!/home/onetop21/base3.7/bin/python
 import sys
 import json
-from pprint import pprint
 from mlad.cli.validator.yaml_parser import load, dump, SCHEMA_PATH
 from mlad.cli.validator.yaml_validator import Validator
 from mlad.cli.validator.exceptions import InvalidProjectYaml

--- a/python/mlad/cli/validator/project_validator.py
+++ b/python/mlad/cli/validator/project_validator.py
@@ -1,0 +1,27 @@
+#!/home/onetop21/base3.7/bin/python
+import sys
+import json
+from pprint import pprint
+from mlad.cli.validator.yaml_parser import load, dump, SCHEMA_PATH
+from mlad.cli.validator.yaml_validator import Validator
+from mlad.cli.validator.exceptions import InvalidProjectYaml
+from cerberus.validator import DocumentError
+
+def validate(project):
+    with open(f'{SCHEMA_PATH}/schema-project.yaml') as f:
+        schema = load(f)
+
+    v = Validator(schema)
+    try:
+        res = v.validate(project)
+    except DocumentError as e:
+        raise InvalidProjectYaml(str(e))
+    if res:
+        print("Project file verified.")
+        output = v.ordered(v.normalized(project))
+        with open("output.yaml", "w") as f:
+            f.write(dump(output))
+        return output
+    else:
+        print(v.errors)
+        raise InvalidProjectYaml(v.errors)

--- a/python/mlad/cli/validator/schema-component.yaml
+++ b/python/mlad/cli/validator/schema-component.yaml
@@ -1,0 +1,14 @@
+!include schema-definitions.yaml
+
+############################
+# MLAppDeploy Project v0.2 #
+############################
+<<: *metadata
+workspace:
+  type: dict
+  selector: [*workspace, *dockerfile]
+app:
+  type: dict
+  valuesrules:
+    type: dict
+    selector: [*component]

--- a/python/mlad/cli/validator/schema-definitions.yaml
+++ b/python/mlad/cli/validator/schema-definitions.yaml
@@ -1,0 +1,251 @@
+# Anchor
+x-definitions:
+  - definition: &metadata
+      apiVersion:
+        type: string
+        regex: "v[0-9]+"
+        default: v1
+        description: Schema version for MLAppDeploy project.
+        order: 0
+      name:
+        type: string
+        required: true
+        empty: false
+        order: 1
+      version:
+        type: string
+        regex: "[0-9]+\\.[0-9]+\\.[0-9]+"
+        default: 0.0.1
+        order: 2
+      maintainer:
+        type: string
+        default: ${USER}
+        order: 3
+      workdir:                    # Describe workspace directory.
+        type: string
+        default: .
+        order: 4
+  - definition: &workspace
+      kind:
+        type: string
+        allowed: [Workspace]
+        default: Workspace
+      base:                       # Describe base docker image tag
+        type: string
+        regex: "(?:.+/)?([^:]+)(?::.+)?"
+        required: true
+      preps:                      # Describe preparations for making envorinment.
+        type: list
+        schema:
+          type: dict
+          schema:
+            run:
+              type: string
+            add:
+              type: string
+            pip:
+              type: string
+            apt:
+              type: string
+            yum:
+              type: string
+            apk:
+              type: string
+      ignores:                    # Describe exclude files from project.
+        type: list
+        default:
+          - "**/.*"
+        schema:                   # Describe script run after copy files.
+          type: string
+      script:
+        type: string
+      env:                        # Describe environment variables.
+        type: dict
+        default:
+          PYTHONUNBUFFERED: 1
+      command:                    # Describe application to execute
+        type: [string, list]
+      args:                       # Describe arguments for execute application
+        type: [string, list]
+  - definition: &dockerfile
+      kind:
+        type: string
+        allowed: [Dockerfile]
+        required: true
+      script:
+        type: string
+        excludes: [filePath, ignorePath]
+        required: true
+      ignores:                    # Describe exclude files from project.
+        type: list
+        default:
+          - "**/.*"
+        schema:                   # Describe script run after copy files.
+          type: string
+        excludes: [filePath, ignorePath]
+      filePath:
+        type: string
+        excludes: [script, ignores]
+        required: true
+      ignorePath:
+        type: string
+        excludes: [script, ignores]
+  - definition: &ingress
+      target:
+        type: string
+        regex: "[A-Za-z0-9-_]+:[0-9]+"
+        required: true
+      rewritePath:
+        type: boolean
+        default: true
+  - definition: &component
+      kind:
+        type: string
+        default: Component
+        allowed: ['Component']
+      image:                      # Describe image to run docker service for run not built image from workspace.
+        type: string
+        regex: "(?:.+/)?([^:]+)(?::.+)?"
+      env:                        # Describe environment variables additionaly.
+        type: dict
+      ports:                      # Describe expose ports to other services.
+        type: list
+        schema:
+          type: integer
+      command:                    # Describe command to need overwrite.
+        type: [string, list]
+      args:                       # Describe arguments to need overwrite.
+        type: [string, list]
+      mounts:
+        type: list
+        schema:
+          type: string
+          regex: "[A-Za-z0-9-_]+:/\\w+"
+        #- ${datastore:URL}:/storage
+  - definition: &_app_base
+      <<: *component
+      kind:                       # component
+        type: string
+        default: App
+        allowed: ['App']
+      constraints:                # Describe placement constraints.
+        type: dict
+        schema:
+          hostname:
+            type: string
+          label:
+            type: dict
+  - definition: &app
+      <<: *_app_base
+      restartPolicy:              # Describe restart policy. (never, onFailure, always)
+        type: string
+        allowed: [never, onFailure, always]
+        default: never
+        excludes: runSpec
+      scale:                      # Describe number of replicas or parallelism
+        type: integer
+        default: 1
+        excludes: runSpec
+      quota:                      # Describe required system resource quota.
+        type: dict
+        excludes: resources
+        schema:
+          cpu:
+            type: number
+          gpu:
+            type: integer
+          mem:
+            type: string
+            regex: "[0-9]+[GMK]?[i]?"
+  - definition: &_advanced_base
+      resources:
+        type: dict
+        excludes: quota
+        schema:
+          limits:
+            type: dict
+            schema:
+              cpu:
+                type: number
+              gpu:
+                type: integer
+              mem:
+                type: string
+                regex: "[0-9]+[GMK]?[i]?"
+          requests:
+            type: dict
+            schema:
+              cpu:
+                type: number
+              gpu:
+                type: integer
+              mem:
+                type: string
+                regex: "[0-9]+[GMK]?[i]?"
+  - definition: &job
+      <<: *_app_base
+      <<: *_advanced_base
+      kind:                     # job
+        type: string
+        allowed: ['Job']
+        required: true
+      runSpec:
+        type: dict
+        excludes: restartPolicy
+        schema:
+          restartPolicy:        # never, onFailure
+            type: string
+            allowed: [never, onFailure]
+            default: never
+          parallelism:
+            type: integer
+            default: 1
+          completion:
+            type: integer
+            default: 1
+  - definition: &service
+      <<: *_app_base
+      <<: *_advanced_base
+      kind:                     # Deployment
+        type: string
+        allowed: ['Service']
+        required: true
+      runSpec:
+        type: dict
+        excludes: restartPolicy
+        schema:
+          replicas:               # Describe number to run service instances.
+            type: integer
+            default: 1
+          autoscaler:
+            type: dict
+            schema:
+              enable:
+                type: boolean
+                default: false
+              min:
+                type: integer
+                default: 1
+              max:
+                type: integer
+                default: 1
+              metrics:
+                type: list
+                schema:
+                  type: dict
+                  schema:
+                    resources:
+                      type: string
+                      allowed: [cpu]
+                      default: cpu
+  - definition: &daemon
+      <<: *_app_base
+      <<: *_advanced_base
+      kind:                    # DaemonSet
+        type: string
+        allowed: ['Daemon']
+        required: true
+      # runSpec:
+      #   type: dict
+      #   excludes: restartPolicy
+      #   schema:

--- a/python/mlad/cli/validator/schema-project.yaml
+++ b/python/mlad/cli/validator/schema-project.yaml
@@ -1,0 +1,24 @@
+!include schema-definitions.yaml
+
+############################
+# MLAppDeploy Project v0.2 #
+############################
+<<: *metadata
+workspace:
+  type: dict
+  selector: [*workspace, *dockerfile]
+  order: 10
+  coerce: selector
+ingress:
+  type: dict
+  valuesrules:
+    type: dict
+    schema: *ingress
+  order: 20
+app:
+  type: dict
+  valuesrules:
+    type: dict
+    selector: [*app, *job, *service]
+    coerce: selector
+  order: 30

--- a/python/mlad/cli/validator/yaml_parser.py
+++ b/python/mlad/cli/validator/yaml_parser.py
@@ -1,0 +1,58 @@
+import os
+import io
+import re
+import yaml
+try:
+    from yaml import CLoader as BaseLoader, CDumper as Dumper
+except ImportError:
+    from yaml import Loader as BaseLoader, Dumper
+from functools import lru_cache
+
+
+SCHEMA_PATH = os.path.dirname(os.path.abspath(__file__))
+
+
+class Loader(BaseLoader):
+    def __init__(self, stream):
+        super(Loader, self).__init__(stream)
+
+    interpolation_matcher = re.compile(r'\$\{([\w.-]+)(|:-([^}^{]+))\}')
+    def interpolation(self, node):
+        ''' Extract the matched value, expand env variable, and replace the match '''
+        value = node.value
+        match = self.interpolation_matcher.match(value)
+        env_var = match.group(1)
+        default = match.group(3) or value
+        if not env_var.startswith('.'):
+            return os.environ.get(env_var, default) + value[match.end():]
+        else:
+            return os.environ.get(env_var, default) + value[match.end():]
+
+Loader.add_implicit_resolver('!interp', Loader.interpolation_matcher, None)
+Loader.add_constructor('!interp', Loader.interpolation)
+
+@lru_cache(maxsize=None)
+def load(file):
+    def sub_load(file):
+        if isinstance(file, io.IOBase):
+            stream = file.read()
+        elif isinstance(file, str) and os.path.isfile(file):
+            with open(file) as f:
+                stream = f.read()
+        else:
+            stream = file
+        for _ in re.finditer(r'!include\s+([\w.-]+)', stream):
+            stream = stream.replace(_.group(0), sub_load(os.path.join(SCHEMA_PATH, _.group(1))))
+        return stream
+    def drop_recursive(data):
+        _data = {}
+        for k, v in data.items():
+            if isinstance(v, dict):
+                v = drop_recursive(v)
+            if not k.startswith('x-'):
+                _data[k] = v
+        return _data
+    return drop_recursive(yaml.load(sub_load(file), Loader=Loader))
+
+def dump(doc):
+    return yaml.dump(doc, Dumper=Dumper, default_flow_style=False)

--- a/python/mlad/cli/validator/yaml_validator.py
+++ b/python/mlad/cli/validator/yaml_validator.py
@@ -1,0 +1,39 @@
+import warnings
+import cerberus
+
+warnings.simplefilter("ignore", UserWarning)
+
+
+class Validator(cerberus.Validator):
+    def _validate_description(self, constraint, field, value):
+        '''For use YAML Editor'''
+
+    def _validate_order(self, constraint, field, value):
+        '''For use YAML Editor'''
+
+    def _validate_selector(self, constraint, field, value):
+        recent_error = None
+        for _ in reversed(constraint):
+            validator = cerberus.Validator(_)
+            if validator.validate(value):
+                return
+            recent_error = validator._errors
+        self._error(recent_error)
+
+    def _normalize_coerce_selector(self, document):
+        for key, value in self.schema.items():
+            for schema in value.get('selector', []):
+                validator = cerberus.Validator(schema)
+                if validator.validate(document):
+                    return validator.normalized(document)
+        print('Not Found suitable selector schema.')
+
+    def ordered(self, document, schema=None):
+        '''For use YAML Editor'''
+        schema = schema or self.schema
+        document = dict(
+            sorted(document.items(), key=lambda x: schema[x[0]].get('order', float('inf'))))
+        for k, v in document.items():
+            if isinstance(v, dict) and schema[k].get('schema'):
+                document[k] = self.ordered(v, schema[k]['schema'])
+        return document

--- a/python/mlad/core/docker/controller.py
+++ b/python/mlad/core/docker/controller.py
@@ -540,8 +540,6 @@ def inspect_image(image):
         raise TypeError('Parameter is not valid type.')
     headed = len([_ for _ in image.tags if _.endswith('latest')]) > 0
     labels = {
-        # for Manifest
-        'type': image.labels['MLAD.PROJECT.TYPE'], 
         # for Image
         'id': image.id.split(':',1)[-1],
         'short_id': image.short_id.split(':',1)[-1],
@@ -553,6 +551,7 @@ def inspect_image(image):
         'maintainer': image.attrs['Author'],
         'created': image.attrs['Created'],
         # for Project
+        'api_version': image.labels['MLAD.PROJECT.API_VERSION'],
         'workspace': image.labels['MLAD.PROJECT.WORKSPACE'] if 'MLAD.PROJECT.WORKSPACE' in image.labels else 'Not Supported',
         'project_name': image.labels['MLAD.PROJECT.NAME'],
     }

--- a/python/mlad/core/kubernetes/controller.py
+++ b/python/mlad/core/kubernetes/controller.py
@@ -280,8 +280,6 @@ def get_service(name, namespace, cli = DEFAULT_CLI):
 def get_services(project_key=None, extra_filters={}, cli=DEFAULT_CLI):
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
-    api = client.CoreV1Api(cli)
-    core_api = client.CoreV1Api(cli)
     batch_api = client.BatchV1Api(cli)
     apps_api = client.AppsV1Api(cli)
     filters = [f'MLAD.PROJECT={project_key}' if project_key else 'MLAD.PROJECT']
@@ -535,22 +533,22 @@ def _resources_to_V1Resource(type='Quota', resources=None):
     if type == 'Quota':
         for type in resources:
             if type == 'cpu': requests['cpu'] = str(resources['cpu']) if resources[type] else None
-            if type == 'gpu': requests['nvidia.com/gpu'] = str(resources['gpu']) \
+            elif type == 'gpu': requests['nvidia.com/gpu'] = str(resources['gpu']) \
                 if resources[type] else None
-            if type == 'mem': requests['memory'] = str(resources['mem']) \
+            elif type == 'mem': requests['memory'] = str(resources['mem']) \
                 if resources[type] else None
         limits = requests
     elif type == 'Resources':
         if 'limits' in resources:
             for type in resources['limits']:
                 if type == 'cpu': limits['cpu'] = str(resources['limits']['cpu'])
-                if type == 'gpu': limits['nvidia.com/gpu'] = str(resources['limits']['gpu'])
-                if type == 'mem': limits['mem'] = str(resources['limits']['mem'])
+                elif type == 'gpu': limits['nvidia.com/gpu'] = str(resources['limits']['gpu'])
+                elif type == 'mem': limits['mem'] = str(resources['limits']['mem'])
         if 'requests' in resources:
             for type in resources['requests']:
                 if type == 'cpu': requests['cpu'] = str(resources['requests']['cpu'])
-                if type == 'gpu': requests['nvidia.com/gpu'] = str(resources['requests']['gpu'])
-                if type == 'mem': requests['mem'] = str(resources['requests']['mem'])
+                elif type == 'gpu': requests['nvidia.com/gpu'] = str(resources['requests']['gpu'])
+                elif type == 'mem': requests['mem'] = str(resources['requests']['mem'])
     return client.V1ResourceRequirements(limits=limits, requests=requests)
 
 

--- a/python/mlad/core/kubernetes/controller.py
+++ b/python/mlad/core/kubernetes/controller.py
@@ -1185,8 +1185,6 @@ def get_service_with_names_or_ids(project_key, names_or_ids=[], cli=DEFAULT_CLI)
         phase = get_pod_info(pod)['phase']
         if not phase == 'Pending':
             targets.append(target)
-        else:
-            print(f'Cannot get logs of pending service: {target[1]}')
 
     if not targets:
         raise exceptions.NotFound("Cannot find running services")

--- a/python/mlad/core/kubernetes/controller.py
+++ b/python/mlad/core/kubernetes/controller.py
@@ -768,13 +768,13 @@ def create_services(network, services, extra_labels={}, cli=DEFAULT_CLI):
         envs = [client.V1EnvVar(name=_.split('=', 1)[0], value=_.split('=', 1)[1])
                for _ in env]
 
-        command = []
-        if service['command']:
-            command += service['command'] if isinstance(service['command'], list) \
-                else service['command'].split()
-        if service['args']:
-            command += service['args'] if isinstance(service['args'], list) \
-                else service['args'].split()
+        command = service['command'] or []
+        args = service['args'] or []
+        if isinstance(command, str):
+            command = command.split()
+        if isinstance(args, str):
+            args = args.split()
+        command += args
 
         labels = copy.copy(network_labels) or {}
         labels.update(extra_labels)

--- a/python/mlad/core/kubernetes/controller.py
+++ b/python/mlad/core/kubernetes/controller.py
@@ -235,7 +235,7 @@ def remove_project_network(network, timeout=0xFFFF, stream=False, cli=DEFAULT_CL
                 break
             else:
                 padding = '\033[1A\033[K' if tick else ''
-                message = f"{padding}Wait to remove network [{tick}s]\n"
+                message = f"{padding}Wait to remove network...[{tick}s]\n"
                 yield {'stream': message}
                 time.sleep(1)
         if not removed:
@@ -397,7 +397,7 @@ def get_pod_info(pod):
         pod_info['status'] = {
             'state': 'Waiting',
             'detail': {
-                'reason': pod.status.conditions[0].reason
+                'reason': pod.status.conditions[0].reason if pod.status.conditions else None
             }
         }
     return pod_info
@@ -507,7 +507,7 @@ def _mounts_to_V1Volume(name, mounts):
     _volumes = []
     if mounts:
         for i, _ in enumerate(mounts):
-            mount_path, host_path = _.split(":")[0], _.split(":")[1]
+            host_path, mount_path = _.split(":")[0], _.split(":")[1]
             volume_name = f'{name}-mnt{i}'
             _mounts.append(
                 client.V1VolumeMount(
@@ -694,7 +694,7 @@ def _create_kind_app(cli, name, image, command, namespace, restart_policy, envs,
     if controller == 'Job':
         res = _create_job(name, image, command, namespace, restart_policy, envs, mounts, scale,
                           None, quota, None, labels, constraints, secrets, cli)
-    elif kind == 'Deployment':
+    elif controller == 'Deployment':
         res = _create_deployment(cli, name, image, command, namespace, envs, mounts, scale,
                                  quota, None, labels, constraints, secrets)
     return res, controller

--- a/python/mlad/core/kubernetes/controller.py
+++ b/python/mlad/core/kubernetes/controller.py
@@ -532,23 +532,32 @@ def _resources_to_V1Resource(type='Quota', resources=None):
     requests = {}
     if type == 'Quota':
         for type in resources:
-            if type == 'cpu': requests['cpu'] = str(resources['cpu']) if resources[type] else None
-            elif type == 'gpu': requests['nvidia.com/gpu'] = str(resources['gpu']) \
+            if type == 'cpu':
+                requests['cpu'] = str(resources['cpu']) if resources[type] else None
+            elif type == 'gpu':
+                requests['nvidia.com/gpu'] = str(resources['gpu']) \
                 if resources[type] else None
-            elif type == 'mem': requests['memory'] = str(resources['mem']) \
+            elif type == 'mem':
+                requests['memory'] = str(resources['mem']) \
                 if resources[type] else None
         limits = requests
     elif type == 'Resources':
         if 'limits' in resources:
             for type in resources['limits']:
-                if type == 'cpu': limits['cpu'] = str(resources['limits']['cpu'])
-                elif type == 'gpu': limits['nvidia.com/gpu'] = str(resources['limits']['gpu'])
-                elif type == 'mem': limits['mem'] = str(resources['limits']['mem'])
+                if type == 'cpu':
+                    limits['cpu'] = str(resources['limits']['cpu'])
+                elif type == 'gpu':
+                    limits['nvidia.com/gpu'] = str(resources['limits']['gpu'])
+                elif type == 'mem':
+                    limits['mem'] = str(resources['limits']['mem'])
         if 'requests' in resources:
             for type in resources['requests']:
-                if type == 'cpu': requests['cpu'] = str(resources['requests']['cpu'])
-                elif type == 'gpu': requests['nvidia.com/gpu'] = str(resources['requests']['gpu'])
-                elif type == 'mem': requests['mem'] = str(resources['requests']['mem'])
+                if type == 'cpu':
+                    requests['cpu'] = str(resources['requests']['cpu'])
+                elif type == 'gpu':
+                    requests['nvidia.com/gpu'] = str(resources['requests']['gpu'])
+                elif type == 'mem':
+                    requests['mem'] = str(resources['requests']['mem'])
     return client.V1ResourceRequirements(limits=limits, requests=requests)
 
 

--- a/python/mlad/core/kubernetes/controller.py
+++ b/python/mlad/core/kubernetes/controller.py
@@ -54,16 +54,17 @@ def get_auth_headers(cli, image_name=None, auth_configs=None):
     return docker_controller.get_auth_headers(docker.from_env(), image_name, auth_configs)
 
 
-def get_project_networks(cli, extra_labels=[]):
+def get_project_networks(extra_labels=[], cli=DEFAULT_CLI):
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
     api = client.CoreV1Api(cli)
-    selector = ['MLAD.PROJECT.TYPE'] + (extra_labels or ['MLAD.PROJECT.TYPE=project'])
+    #selector = ['MLAD.PROJECT.TYPE'] + (extra_labels or ['MLAD.PROJECT.TYPE=project'])
+    selector = ['MLAD.PROJECT'] + extra_labels
     namespaces = api.list_namespace(label_selector=','.join(selector))
     return dict([(_.metadata.name, _) for _ in namespaces.items])
 
 
-def get_project_network(cli, **kwargs):
+def get_project_network(cli=DEFAULT_CLI, **kwargs):
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
     api = client.CoreV1Api(cli)
@@ -96,15 +97,13 @@ def get_labels(obj):
         raise TypeError('Parameter is not valid type.')
 
 
-def get_config_labels(cli, obj, key):
+def get_config_labels(namespace, key, cli=DEFAULT_CLI):
     # key='project-labels', 'service-{name}-labels'
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
     api = client.CoreV1Api(cli)
-    if isinstance(obj, client.models.v1_namespace.V1Namespace):
-        namespace = obj.metadata.name
-    elif isinstance(obj, client.models.v1_service.V1Service):
-        namespace = obj.metadata.namespace
+    if isinstance(namespace, client.models.v1_namespace.V1Namespace):
+        namespace = namespace.metadata.name
     ret = api.read_namespaced_config_map(key, namespace)
     return ret.data
 
@@ -123,14 +122,14 @@ def create_config_labels(cli, key, namespace, labels):
     return ret.data
 
 
-def inspect_project_network(cli, network):
+def inspect_project_network(network, cli=DEFAULT_CLI):
     if not isinstance(network, client.models.v1_namespace.V1Namespace):
         raise TypeError('Parameter is not valid type.')
     labels = get_labels(network)
     if network.metadata.deletion_timestamp:
         return {'deleted': True, 'key': uuid.UUID(labels['MLAD.PROJECT'])}
     created = network.metadata.creation_timestamp
-    config_labels = get_config_labels(cli, network, 'project-labels')
+    config_labels = get_config_labels(network, 'project-labels', cli)
     hostname, path = config_labels['MLAD.PROJECT.WORKSPACE'].split(':')
     return {
         'key': uuid.UUID(labels['MLAD.PROJECT']),
@@ -149,14 +148,15 @@ def inspect_project_network(cli, network):
     }
 
 
-def get_project_session(cli, network):
+def get_project_session(network, cli=DEFAULT_CLI):
     if not isinstance(network, client.models.v1_namespace.V1Namespace):
         raise TypeError('Parameter is not valid type.')
-    config_labels = get_config_labels(cli, network, 'project-labels')
+    config_labels = get_config_labels(network, 'project-labels', cli)
     return config_labels['MLAD.PROJECT.SESSION']
 
 
-def create_project_network(cli, base_labels, extra_envs, credential, allow_reuse=False, stream=False):
+def create_project_network(base_labels, extra_envs, credential, allow_reuse=False, stream=False,
+                           cli=DEFAULT_CLI):
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
     api = client.CoreV1Api(cli)
@@ -173,8 +173,6 @@ def create_project_network(cli, base_labels, extra_envs, credential, allow_reuse
                 return (network, stream_out)
         raise NetworkAlreadyExistError(project_key)
     basename = base_labels['MLAD.PROJECT.BASE']
-    # project_version = base_labels['MLAD.PROJECT.VERSION']
-    # default_image = base_labels['MLAD.PROJECT.IMAGE']
 
     def resp_stream():
         network_name = f"{basename}-cluster"
@@ -190,7 +188,7 @@ def create_project_network(cli, base_labels, extra_envs, credential, allow_reuse
             keys = {
                 'MLAD.PROJECT': labels['MLAD.PROJECT'],
                 'MLAD.PROJECT.NAME': labels['MLAD.PROJECT.NAME'],
-                'MLAD.PROJECT.TYPE': labels['MLAD.PROJECT.TYPE'],
+                #'MLAD.PROJECT.TYPE': labels['MLAD.PROJECT.TYPE'],
             }
             api.create_namespace(
                 client.V1Namespace(
@@ -220,13 +218,13 @@ def create_project_network(cli, base_labels, extra_envs, credential, allow_reuse
         return (get_project_network(cli, project_key=project_key), stream_out)
 
 
-def remove_project_network(cli, network, timeout=0xFFFF, stream=False):
+def remove_project_network(network, timeout=0xFFFF, stream=False, cli=DEFAULT_CLI):
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
     if not isinstance(network, client.models.v1_namespace.V1Namespace):
         raise TypeError('Parameter is not valid type.')
     api = client.CoreV1Api(cli)
-    network_info = inspect_project_network(cli, network)
+    network_info = inspect_project_network(network, cli)
     api.delete_namespace(network.metadata.name)
 
     def resp_stream():
@@ -257,46 +255,74 @@ def get_containers(cli, project_key=None, extra_filters={}):
     return docker_controller.get_containers(docker.from_env(), project_key, extra_filters)
 
 
-def get_services(cli, project_key=None, extra_filters={}):
+def _get_job(cli, name, namespace):
+    api = client.BatchV1Api(cli)
+    return api.read_namespaced_job(name, namespace)
+
+
+def _get_deployment(cli, name, namespace):
+    api = client.AppsV1Api(cli)
+    return api.read_namespaced_deployment(name, namespace)
+
+
+def get_service(name, namespace, cli = DEFAULT_CLI):
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
     api = client.CoreV1Api(cli)
+    key = f'service-{name}-labels'
+    config_labels = get_config_labels(namespace, key, cli)
+    controller = config_labels['MLAD.PROJECT.SERVICE.CONTROLLER']
+    name = config_labels['MLAD.PROJECT.SERVICE']
+    service = get_service_from_controller(cli, name, namespace, controller)
+    return service
+
+
+def get_services(project_key=None, extra_filters={}, cli=DEFAULT_CLI):
+    if not isinstance(cli, client.api_client.ApiClient):
+        raise TypeError('Parameter is not valid type.')
+    api = client.CoreV1Api(cli)
+    core_api = client.CoreV1Api(cli)
+    batch_api = client.BatchV1Api(cli)
+    apps_api = client.AppsV1Api(cli)
     filters = [f'MLAD.PROJECT={project_key}' if project_key else 'MLAD.PROJECT']
     filters += [f'{key}={value}' for key, value in extra_filters.items()]
-    services = api.list_service_for_all_namespaces(label_selector=','.join(filters))
+
+    services = []
+    services += batch_api.list_job_for_all_namespaces(label_selector=','.join(filters)).items
+    services += apps_api.list_deployment_for_all_namespaces(label_selector=','.join(filters)).items
+
     if project_key:
-        return dict([(_.metadata.labels['MLAD.PROJECT.SERVICE'], _) for _ in services.items])
+        return dict([(_.metadata.labels['MLAD.PROJECT.SERVICE'], _) for _ in services])
     else:
-        return dict([(_.metadata.name, _) for _ in services.items])
+        return dict([(_.metadata.name, _) for _ in services])
 
 
-def get_service(cli, **kwargs):
+def get_deployed_service(cli, namespace, name):
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
     api = client.CoreV1Api(cli)
-    if kwargs.get('service_id'):
-        service = api.list_service_for_all_namespaces(label_selector=f"uid={kwargs.get('service_id')}")
-    elif kwargs.get('service_name') and kwargs.get('namespace'):
-        service = api.list_namespaced_service(kwargs.get('namespace'),
-                                              label_selector=f"MLAD.PROJECT.SERVICE={kwargs.get('service_name')}" )
+    service = api.list_namespaced_service(
+        namespace, label_selector=f"MLAD.PROJECT.SERVICE={name}")
     if not service.items:
         return None
     elif len(service.items) == 1:
         return service.items[0]
 
 
-def get_service_from_kind(cli, service_name, namespace, kind):
+def get_service_from_controller(cli, service_name, namespace, controller):
     # get job or rc of service
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
     core_api = client.CoreV1Api(cli)
     batch_api = client.BatchV1Api(cli)
-    if kind == 'job':
+    apps_api = client.AppsV1Api(cli)
+    if controller == 'Job':
         service = batch_api.list_namespaced_job(
             namespace, label_selector=f"MLAD.PROJECT.SERVICE={service_name}")
-    elif kind == 'rc':
-        service = core_api.list_namespaced_replication_controller(
+    elif controller == 'Deployment':
+        service = apps_api.list_namespaced_deployment(
             namespace, label_selector=f"MLAD.PROJECT.SERVICE={service_name}")
+
     if not service.items:
         return None
     elif len(service.items) == 1:
@@ -379,36 +405,32 @@ def get_pod_info(pod):
     return pod_info
 
 
-def _get_job(cli, name, namespace):
-    api = client.BatchV1Api(cli)
-    return api.read_namespaced_job(name, namespace)
+def inspect_service(service, cli=DEFAULT_CLI):
+    controller = None
+    if isinstance(service, client.models.v1_deployment.V1Deployment):
+        controller = 'Deployment'
+    elif isinstance(service, client.models.v1_job.V1Job):
+        controller = 'Job'
+    else: raise TypeError('Parameter is not valid type.')
 
-
-def _get_replication_controller(cli, name, namespace):
     api = client.CoreV1Api(cli)
-    return api.read_namespaced_replication_controller(name, namespace)
 
-
-def inspect_service(cli, service):
-    if not isinstance(service, client.models.v1_service.V1Service): raise TypeError('Parameter is not valid type.')
-    api = client.CoreV1Api(cli)
-    service_name = service.metadata.name
+    name = service.metadata.name
     namespace = service.metadata.namespace
-    config_labels = get_config_labels(cli, service,
-                                      f'service-{service_name}-labels')
-    labels = service.metadata.labels
+    config_labels = get_config_labels(namespace, f'service-{name}-labels', cli)
 
-    kind = config_labels['MLAD.PROJECT.SERVICE.KIND']
-    if kind == 'job':
-        replica_ret = _get_job(cli, service_name, namespace)
-    elif kind == 'rc':
-        replica_ret = _get_replication_controller(cli, service_name, namespace)
-    pod_ret = api.list_namespaced_pod(namespace, label_selector=f'MLAD.PROJECT.SERVICE={service_name}')
+    if controller == 'Job':
+        replica_ret = _get_job(cli, name, namespace)
+    elif controller == 'Deployment':
+        replica_ret = _get_deployment(cli, name, namespace)
+    pod_ret = api.list_namespaced_pod(namespace,
+                                      label_selector=f'MLAD.PROJECT.SERVICE={name}')
 
     hostname, path = config_labels.get('MLAD.PROJECT.WORKSPACE', ':').split(':')
-   
+
     inspect = {
-        'key': uuid.UUID(config_labels['MLAD.PROJECT']) if config_labels.get('MLAD.VERSION') else '',
+        'key': uuid.UUID(config_labels['MLAD.PROJECT']) if config_labels.get(
+            'MLAD.VERSION') else '',
         'workspace': {
             'hostname': hostname,
             'path': path
@@ -416,28 +438,34 @@ def inspect_service(cli, service):
         'username': config_labels.get('MLAD.PROJECT.USERNAME'),
         'network': config_labels.get('MLAD.PROJECT.NETWORK'),
         'project': config_labels.get('MLAD.PROJECT.NAME'),
-        'project_id': uuid.UUID(config_labels['MLAD.PROJECT.ID']) if config_labels.get('MLAD.VERSION') else '',
+        'project_id': uuid.UUID(config_labels['MLAD.PROJECT.ID']) if config_labels.get(
+            'MLAD.VERSION') else '',
         'version': config_labels.get('MLAD.PROJECT.VERSION'),
         'base': config_labels.get('MLAD.PROJECT.BASE'),
-        'image': replica_ret.spec.template.spec.containers[0].image, # Replace from labels['MLAD.PROJECT.IMAGE']
+        'image': replica_ret.spec.template.spec.containers[0].image,
+        # Replace from labels['MLAD.PROJECT.IMAGE']
 
         'id': service.metadata.uid,
-        'name': config_labels.get('MLAD.PROJECT.SERVICE'), 
-        'replicas': replica_ret.spec.parallelism if kind == 'job' else replica_ret.spec.replicas,
+        'name': config_labels.get('MLAD.PROJECT.SERVICE'),
+        'replicas': replica_ret.spec.parallelism if controller == 'Job'
+            else replica_ret.spec.replicas,
         'tasks': dict([(pod.metadata.name, get_pod_info(pod)) for pod in pod_ret.items]),
         'ports': {},
         'ingress': config_labels.get('MLAD.PROJECT.INGRESS'),
         'created': replica_ret.metadata.creation_timestamp,
+        'kind': config_labels.get('MLAD.PROJECT.SERVICE.KIND')
     }
 
-    if service.spec.ports:
-        for _ in service.spec.ports:
-            target = _.target_port
-            published = _.port
-            inspect['ports'][f"{target}->{published}"] = {
-                'target': target,
-                'published': published
-            }
+    deployed_service = get_deployed_service(cli, namespace, name)
+    if deployed_service:
+        if deployed_service.spec.ports:
+            for _ in deployed_service.spec.ports:
+                target = _.target_port
+                published = _.port
+                inspect['ports'][f"{target}->{published}"] = {
+                    'target': target,
+                    'published': published
+                }
     return inspect
 
 
@@ -445,23 +473,119 @@ def create_containers(cli, network, services, extra_labels={}):
     return docker_controller.create_containers(docker.from_env(), network, services, extra_labels)
 
 
-def _create_job(cli, name, image, command, namespace='default', envs=None, 
-                restart_policy='Never', replicas=1, cpu=None, gpu=None, mem=None, 
-                labels=None, constraints={}, secrets=None):
-    resources = {}
-    if cpu: resources['cpu'] = str(cpu)
-    if gpu: resources['nvidia.com/gpu'] = str(gpu)
-    if mem: resources['memory'] = str(mem)
-    # hostname: docker-desktop -> kubernetes.io/hostname: docker-desktop
-    # labels.hello: world      -> hello: world
-    constraints = dict([(_[7:] if _.startswith('labels.') else f"kubernetes.io/{_}", constraints[_]) for _ in constraints])
+def _create_autoscaler(cli, namespace, name, labels, spec):
+    api = client.AutoscalingV2beta2Api(cli)
+
+    metrics = spec['metrics']
+    _metrics = [client.V2beta2MetricSpec(
+        type='Resource',
+        resource=client.V2beta2ResourceMetricSource(
+            name=_['resources'], #ex. cpu, memory
+            target=client.V2beta2MetricTarget(
+                type='Utilization',
+                average_utilization=60
+            )
+        )) for _ in metrics]
+
+    body = client.V2beta2HorizontalPodAutoscaler(
+        metadata=client.V1ObjectMeta(name=name, labels=labels),
+        spec=client.V2beta2HorizontalPodAutoscalerSpec(
+            max_replicas=spec['max'],
+            min_replicas=spec['min'],
+            metrics=_metrics,
+            scale_target_ref=client.V2beta2CrossVersionObjectReference(
+                api_version='apps/v1',
+                kind='Deployment',
+                name=name
+            )
+        )
+    )
+    api_response = api.create_namespaced_horizontal_pod_autoscaler(namespace, body)
+    return api_response
+
+
+def _mounts_to_V1Volume(name, mounts):
+    _mounts = []
+    _volumes = []
+    if mounts:
+        for i, _ in enumerate(mounts):
+            mount_path, host_path = _.split(":")[0], _.split(":")[1]
+            volume_name = f'{name}-mnt{i}'
+            _mounts.append(
+                client.V1VolumeMount(
+                    name=volume_name,
+                    mount_path=mount_path,
+                )
+            )
+            _volumes.append(
+                client.V1Volume(
+                    name=volume_name,
+                    host_path=client.V1HostPathVolumeSource(
+                        path=host_path
+                        #type=Directory
+                    )
+                )
+            )
+    return _mounts, _volumes
+
+
+def _resources_to_V1Resource(type='Quota', resources=None):
+    limits = {}
+    requests = {}
+    if type == 'Quota':
+        for type in resources:
+            if type == 'cpu': requests['cpu'] = str(resources['cpu']) if resources[type] else None
+            if type == 'gpu': requests['nvidia.com/gpu'] = str(resources['gpu']) \
+                if resources[type] else None
+            if type == 'mem': requests['memory'] = str(resources['mem']) \
+                if resources[type] else None
+        limits = requests
+    elif type == 'Resources':
+        if 'limits' in resources:
+            for type in resources['limits']:
+                if type == 'cpu': limits['cpu'] = str(resources['limits']['cpu'])
+                if type == 'gpu': limits['nvidia.com/gpu'] = str(resources['limits']['gpu'])
+                if type == 'mem': limits['mem'] = str(resources['limits']['mem'])
+        if 'requests' in resources:
+            for type in resources['requests']:
+                if type == 'cpu': requests['cpu'] = str(resources['requests']['cpu'])
+                if type == 'gpu': requests['nvidia.com/gpu'] = str(resources['requests']['gpu'])
+                if type == 'mem': requests['mem'] = str(resources['requests']['mem'])
+    return client.V1ResourceRequirements(limits=limits, requests=requests)
+
+
+def _constraints_to_labels(constraints):
+    _constraints = {}
+    if constraints:
+        for k, v in constraints.items():
+            if constraints[k]:
+                if k == 'hostname':
+                    _constraints["kubernetes.io/hostname"] = v
+                else:
+                    for _ in v:
+                        _constraints[_] = str(v[_])
+    return _constraints
+
+
+def _create_job(name, image, command, namespace='default', restart_policy='Never',
+                envs=None, mounts=None, parallelism=None, completions=None, quota=None, resources=None,
+                labels=None, constraints=None, secrets=None, cli=DEFAULT_CLI):
+
+    _resources = _resources_to_V1Resource(resources=quota) if quota \
+        else _resources_to_V1Resource(type='Resources', resources=resources) if resources \
+        else None
+
+    _constraints =_constraints_to_labels(constraints)
+
+    _mounts, _volumes = _mounts_to_V1Volume(name, mounts)
 
     api = client.BatchV1Api(cli)
     body=client.V1Job(
         metadata=client.V1ObjectMeta(name=name,labels=labels),
         spec=client.V1JobSpec(
             backoff_limit=0,
-            parallelism=replicas,
+            parallelism=parallelism,
+            completions=completions,
             selector={'MLAD.PROJECT.SERVICE': name},
             template=client.V1PodTemplateSpec(
                 metadata=client.V1ObjectMeta(name=name, labels=labels),
@@ -475,156 +599,178 @@ def _create_job(cli, name, image, command, namespace='default', envs=None,
                             image_pull_policy='Always', #TODO modify to option
                             command=command,
                             env=envs,
-                            resources=client.V1ResourceRequirements(
-                                limits=dict(
-                                    list(resources.items())
-                                ),
-                                requests=dict(
-                                    list(resources.items())
-                                )
-                            )
+                            resources=_resources,
+                            volume_mounts=_mounts
                         )
                     ],
-                    node_selector = constraints,
-                    image_pull_secrets=[client.V1LocalObjectReference(name=secrets)] if secrets else None
+                    volumes=_volumes,
+                    node_selector = _constraints,
+                    image_pull_secrets=[client.V1LocalObjectReference(name=secrets)]
+                    if secrets else None
                 )
             )
-        )  
+        )
     )
     api_response = api.create_namespaced_job(namespace, body)
     return api_response
 
 
-def _create_replication_controller(cli, name, image, command, namespace='default',
-                                   envs=None, restart_policy='Always', 
-                                   replicas=1, cpu=None, gpu=None, mem=None,
-                                   labels=None, constraints={}, secrets=None):
-    resources = {}
-    if cpu:
-        resources['cpu'] = str(cpu)
-    if gpu:
-        resources['nvidia.com/gpu'] = str(gpu)
-    if mem:
-        resources['memory'] = str(mem)
-    constraints = dict([(_[7:] if _.startswith('labels.') else f"kubernetes.io/{_}", constraints[_])
-                        for _ in constraints])
+def _create_deployment(cli, name, image, command, namespace='default',
+                       envs=None, mounts=None, replicas=1, quota=None, resources=None,
+                       labels=None, constraints=None, secrets=None):
 
-    api = client.CoreV1Api(cli)
-    body=client.V1ReplicationController(
+    _resources = _resources_to_V1Resource(resources=quota) if quota \
+        else _resources_to_V1Resource(type='Resources', resources=resources) if resources \
+        else None
+
+    _constraints = _constraints_to_labels(constraints)
+
+    _mounts, _volumes = _mounts_to_V1Volume(name, mounts)
+
+    api = client.AppsV1Api(cli)
+    body = client.V1Deployment(
         metadata=client.V1ObjectMeta(
             name=name,
             labels=labels
         ),
-        spec=client.V1ReplicationControllerSpec(
+        spec=client.V1DeploymentSpec(
             replicas=replicas,
-            selector={'MLAD.PROJECT.SERVICE': name},
+            selector=client.V1LabelSelector(
+                match_labels={'MLAD.PROJECT.SERVICE': name}
+            ),
             template=client.V1PodTemplateSpec(
                 metadata=client.V1ObjectMeta(
                     name=name,
                     labels=labels
                 ),
-                spec=client.V1PodSpec(
-                    restart_policy=restart_policy, #Always, OnFailure, Never
+                spec = client.V1PodSpec(
+                    restart_policy='Always',
                     containers=[client.V1Container(
                         name=name,
                         image=image,
-                        image_pull_policy='Always',  # TODO modify to option
+                        image_pull_policy='Always',
                         env=envs,
                         command=command,
-                        resources=client.V1ResourceRequirements(
-                            limits=dict(
-                                list(resources.items())
-                            ),
-                            requests=dict(
-                                list(resources.items())
-                            )
-                        )
+                        resources=_resources,
+                        volume_mounts=_mounts
                     )],
-                    node_selector = constraints,
-                    image_pull_secrets=[client.V1LocalObjectReference(name=secrets)] if secrets else None
+                    volumes=_volumes,
+                    node_selector=_constraints,
+                    image_pull_secrets=[client.V1LocalObjectReference(name=secrets)]
+                    if secrets else None
                 )
             )
         )
     )
-    api_response = api.create_namespaced_replication_controller(namespace, body)
+
+    api_response = api.create_namespaced_deployment(namespace, body)
     return api_response
 
 
-def create_services(cli, network, services, extra_labels={}):
+def _create_kind_app(cli, name, image, command, namespace, restart_policy, envs, mounts,
+                     scale, quota, labels, constraints, secrets):
+
+    RESTART_POLICY_STORE = {
+        'never': 'Never',
+        'onfailure': 'OnFailure',
+        'always': 'Always',
+    }
+    CONTROLLER_STORE = {
+        'Never': 'Job',
+        'OnFailure': 'Job',
+        'Always': 'Deployment'
+    }
+
+    restart_policy = RESTART_POLICY_STORE.get(restart_policy.lower(), 'Never')
+    controller = CONTROLLER_STORE.get(restart_policy, 'Job')
+
+    if controller == 'Job':
+        res = _create_job(name, image, command, namespace, restart_policy, envs, mounts, scale,
+                          None, quota, None, labels, constraints, secrets, cli)
+    elif kind == 'Deployment':
+        res = _create_deployment(cli, name, image, command, namespace, envs, mounts, scale,
+                                 quota, None, labels, constraints, secrets)
+    return res, controller
+
+
+def _create_kind_job(cli, name, image, command, namespace, envs, mounts, run_spec, resources,
+                     labels, constraints, secrets):
+
+    RESTART_POLICY_STORE = {
+        'never': 'Never',
+        'onfailure': 'OnFailure',
+        'always': 'Always',
+    }
+
+    restart_policy =  RESTART_POLICY_STORE.get(run_spec['restartPolicy'], 'Never') \
+        if run_spec else 'Never'
+    completions = run_spec['completion'] if run_spec else None
+    parallelism = run_spec['parallelism'] if run_spec else 1
+    res = _create_job(name, image, command, namespace, restart_policy, envs, mounts, parallelism,
+                      completions, None, resources, labels, constraints, secrets, cli)
+    return res
+
+
+def _create_kind_service(cli, name, image, command, namespace, envs, mounts, run_spec,
+                         resources, labels, constraints, secrets):
+    autoscaler_spec = None
+    if run_spec:
+        replicas = run_spec['replicas']
+        autoscaler_spec = run_spec['autoscaler'] if 'autoscaler' in run_spec else None
+    else:
+        replicas = 1
+
+    res = _create_deployment(cli, name, image, command, namespace, envs, mounts, replicas,
+                             None, resources, labels, constraints, secrets)
+    if autoscaler_spec:
+        try:
+            autoscaler_res = _create_autoscaler(cli, namespace, name, labels, autoscaler_spec)
+        except ValueError as e:
+            if 'Invalid value for `conditions`' in str(e):
+                pass
+    return res
+
+
+def create_services(network, services, extra_labels={}, cli=DEFAULT_CLI):
     if not isinstance(cli, client.api_client.ApiClient): raise TypeError('Parameter is not valid type.')
     if not isinstance(network, client.models.v1_namespace.V1Namespace): raise TypeError('Parameter is not valid type.')
     api = client.CoreV1Api(cli)
     namespace = network.metadata.name
-    project_info = inspect_project_network(cli, network)
-    config_labels = get_config_labels(cli, network, 'project-labels')
+    project_info = inspect_project_network(network, cli)
+    config_labels = get_config_labels(network, 'project-labels', cli)
     network_labels = get_labels(network)
-    # Update Project Name
-    #project_info = inspect_project_network(network)
+
     image_name = project_info['image']
     project_base = project_info['base']
-    
+
     instances = []
-    for name in services:
-        service = service_default(services[name])
+    for name, service in services.items():
+        #service = service_default(services[name])
 
         # Check running already
-        if get_services(cli, project_info['key'], extra_filters={'MLAD.PROJECT.SERVICE': name}):
+        if get_services(project_info['key'], extra_filters={'MLAD.PROJECT.SERVICE': name}, cli=cli):
             raise exceptions.Duplicated('Already running service.')
     
         image = service['image'] or image_name
         env = utils.decode_dict(config_labels['MLAD.PROJECT.ENV'])
+        env += [f"{key}={service['env'][key]}" for key in service['env'].keys()] \
+            if service['env'] else []
         env += [f"TF_CPP_MIN_LOG_LEVEL=3"]
         env += [f"PROJECT={project_info['project']}"]
         env += [f"USERNAME={project_info['username']}"]
         env += [f"PROJECT_KEY={project_info['key']}"]
         env += [f"PROJECT_ID={project_info['id']}"]
         env += [f"SERVICE={name}"]
-        env += [f"{key}={service['env'][key]}" for key in service['env'].keys()]
-        command = f"{service['command']} {service['arguments']}".strip()
+        #env += [f"{key}={service['env'][key]}" for key in service['env'].keys()]
+        command = f"{service['command']} {service['args']}".strip()
         labels = copy.copy(network_labels)
         labels.update(extra_labels)
         labels['MLAD.PROJECT.SERVICE'] = name
-        
-        replicas = service['deploy']['replicas'] or 1
-        restart_policy = service['deploy']['restart_policy']['condition'] or 'Never'
-        constraints = service['deploy']['constraints']
 
-        # Resource Spec
-        resources = service['deploy']['quota']
-        cpu = resources['cpus'] if 'cpus' in resources else None 
-        gpu = resources['gpus'] if 'gpus' in resources else None
-        mem = resources['mems'] if 'mems' in resources else None
-
-        # if 'mems' in service['deploy']['quota']: 
-        #     data = str(service['deploy']['quota']['mems'])
-        #     size = int(data[:-1])
-        #     unit = data.lower()[-1:]
-        #     if unit == 'g':
-        #         size *= (2**30)
-        #     elif unit == 'm':
-        #         size *= (2**20)
-        #     elif unit == 'k':
-        #         size *= (2**10)
-        #     res_spec['mem_limit'] = size
-        #     res_spec['mem_reservation'] = size
-
-        RESTART_POLICY_STORE = {
-            'never': 'Never',           # JOB Controller
-            'no': 'Never',              # JOB Controller
-            'on_failure': 'OnFailure',  # Job Controller
-            'on-failure': 'OnFailure',  # Job Controller
-            'onfailure': 'OnFailure',   # Replication Controller
-            'always': 'Always',
-        }
-        CONTROLLER_STORE = {
-            'Never': 'job',
-            'OnFailure': 'job',
-            'Always': 'rc'
-        }
-
-        restart_policy = RESTART_POLICY_STORE.get(restart_policy.lower(), 'Never')
-        kind = CONTROLLER_STORE.get(restart_policy, 'job')
-        ports = service['ports'] or [80]
+        constraints = service['constraints']
+        ingress = service['ingress'] if 'ingress' in service else None
+        mounts = service['mounts'] or []
+        kind = service['kind']
         
         # Try to run
         inst_name = f"{project_base}-{name}"
@@ -632,13 +778,14 @@ def create_services(cli, network, services, extra_labels={}):
             'name': inst_name,
             #hostname=f'{name}.{{{{.Task.Slot}}}}',
             'image': image, 
-            'env': env + ['TASK_ID={{.Task.ID}}', f'TASK_NAME={name}.{{{{.Task.Slot}}}}', 'NODE_HOSTNAME={{.Node.Hostname}}'],
-            'mounts': ['/etc/timezone:/etc/timezone:ro', '/etc/localtime:/etc/localtime:ro'],
+            'env': env + ['TASK_ID={{.Task.ID}}', f'TASK_NAME={name}.{{{{.Task.Slot}}}}',
+                          'NODE_HOSTNAME={{.Node.Hostname}}'],
+            'mounts': ['/etc/timezone:/etc/timezone:ro', '/etc/localtime:/etc/localtime:ro']
+                      + mounts,
             'command': command.split(),
             'container_labels': labels,
             'labels': labels,
             'networks': [{'Target': namespace, 'Aliases': [name]}],
-            'restart_policy': restart_policy,
             'constraints': constraints,
         }
 
@@ -646,66 +793,65 @@ def create_services(cli, network, services, extra_labels={}):
                for _ in env]
         command = kwargs.get('command', [])
         labels = kwargs.get('labels', {})
+        mounts = kwargs.get('mounts', [])
 
-        config_labels['MLAD.PROJECT.SERVICE']=name
-        config_labels['MLAD.PROJECT.SERVICE.KIND']=kind
-        ingress_path = None
-        if 'expose' in service:
-            if not 'service_type' in service:
-                ingress_path = f"/ingress/{project_info['username']}/{project_info['name']}/{name}"
-            elif service['service_type'] == 'plugin':
-                ingress_path = f"/plugins/{project_info['username']}/{name}"
-            envs.append(client.V1EnvVar(name='INGRESS_PATH', value=ingress_path))
-            config_labels['MLAD.PROJECT.INGRESS'] = ingress_path
+        config_labels['MLAD.PROJECT.SERVICE'] = name
+        config_labels['MLAD.PROJECT.SERVICE.KIND'] = kind
 
         # Secrets
         secrets = f"{project_base}-auth"
 
         try:
-            if kind == 'job':
-                restart_policy = kwargs.get(restart_policy, 'Never')
-                ret = _create_job(
-                    cli, name, image, command, 
-                    namespace, envs, restart_policy, replicas,
-                    cpu, gpu, mem, labels, constraints, secrets)
-            elif kind == 'rc':
-                restart_policy = kwargs.get(restart_policy, 'Always')
-                ret = _create_replication_controller(
-                    cli, name, image, command, 
-                    namespace, envs, restart_policy, replicas,
-                    cpu, gpu, mem, labels, constraints, secrets)
-            
-            ret = api.create_namespaced_service(namespace, client.V1Service(
-                metadata=client.V1ObjectMeta(
-                    name=name,
-                    labels=labels
-                ),
-                spec=client.V1ServiceSpec(
-                    selector={'MLAD.PROJECT.SERVICE': name},
-                    ports=[client.V1ServicePort(port=_) for _ in ports]
-                )
-            ))
-            if ingress_path:
-                ingress_ret = create_ingress(cli, namespace, name, service['expose'], ingress_path)
+            if kind == 'App':
+                restart_policy = service['restartPolicy']
+                scale = service['scale']
+                quota = service['quota']
+                ret, controller = _create_kind_app(
+                    cli, name, image, command, namespace, restart_policy, envs, mounts, scale,
+                    quota, labels, constraints, secrets)
+                config_labels['MLAD.PROJECT.SERVICE.CONTROLLER'] = controller
+            elif kind == 'Job':
+                resources = service['resources']
+                run_spec = service['runSpec']
+                ret = _create_kind_job(
+                    cli, name, image, command, namespace, envs, mounts, run_spec, resources, labels,
+                    constraints, secrets)
+                config_labels['MLAD.PROJECT.SERVICE.CONTROLLER'] = 'Job'
+            elif kind == 'Service':
+                resources = service['resources']
+                run_spec = service['runSpec']
+                ret = _create_kind_service(
+                    cli, name, image, command, namespace, envs, mounts, run_spec, resources, labels,
+                    constraints, secrets)
+                config_labels['MLAD.PROJECT.SERVICE.CONTROLLER'] = 'Deployment'
+            instances.append(ret)
 
-            label_body = {
-                "metadata": {
-                    "labels": {'uid':ret.metadata.uid}
-                    }
-            }
-            temp_ret = api.patch_namespaced_service(name, namespace, label_body)
-            instances.append(temp_ret)
+            if service['ports']:
+                ret = api.create_namespaced_service(namespace, client.V1Service(
+                    metadata=client.V1ObjectMeta(
+                        name=name,
+                        labels=labels
+                    ),
+                    spec=client.V1ServiceSpec(
+                        selector={'MLAD.PROJECT.SERVICE': name},
+                        ports=[client.V1ServicePort(port=_) for _ in service['ports']]
+                    )
+                ))
+
+            if ingress:
+                ingress_name = ingress['name']
+                rewritePath = ingress['rewritePath']
+                port = int(ingress['port'])
+                ingress_path = f"/{project_info['username']}/{project_info['name']}/{name}"
+                envs.append(client.V1EnvVar(name='INGRESS_PATH', value=ingress_path))
+                config_labels['MLAD.PROJECT.INGRESS'] = ingress_path
+
+                ingress_ret = create_ingress(cli, namespace, name, ingress_name, port,
+                                             ingress_path, rewritePath)
+
             create_config_labels(cli, f'service-{name}-labels', namespace, config_labels)
         except ApiException as e:
-            print(f"Exception Handling CoreV1Api => {e}", file=sys.stderr)
-            if e.headers['Content-Type'] == 'application/json':
-                body = json.loads(e.body)
-                if body['kind'] == 'Status':
-                    msg = body['message']
-                    status = body['code']
-                else:
-                    msg = str(e)
-                    status = 500
+            msg, status = exceptions.handle_k8s_api_error(e)
             err_msg = f'Failed to create services: {msg}'
             raise exceptions.APIError(err_msg, status)
     return instances
@@ -716,37 +862,40 @@ def remove_containers(cli, containers):
 
 
 def _delete_job(cli, name, namespace):
+    if not isinstance(cli, client.api_client.ApiClient):
+        raise TypeError('Parameter is not valid type.')
     api = client.BatchV1Api(cli)
     return api.delete_namespaced_job(name, namespace, propagation_policy='Foreground')
 
 
-def _delete_replication_controller(cli, name, namespace):
-    api = client.CoreV1Api(cli)
-    return api.delete_namespaced_replication_controller(name, 
-        namespace, propagation_policy='Foreground')
+def _delete_deployment(cli, name, namespace):
+    if not isinstance(cli, client.api_client.ApiClient):
+        raise TypeError('Parameter is not valid type.')
+    api = client.AppsV1Api(cli)
+    return api.delete_namespaced_deployment(name, namespace, propagation_policy='Foreground')
 
 
-def remove_services(cli, services, disconnHandler=None, timeout=0xFFFF, stream=False):
+def remove_services(services, disconnHandler=None, timeout=0xFFFF, stream=False, cli=DEFAULT_CLI):
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
     api = client.CoreV1Api(cli)
     network_api = client.NetworkingV1beta1Api(cli)
 
     def _get_service_info(service):
-        inspect = inspect_service(cli, service)
+        inspect = inspect_service(service, cli)
         service_name = inspect['name']
         namespace = service.metadata.namespace
         targets = list(inspect['tasks'].keys())
 
-        config_labels = get_config_labels(cli, service,
-            f'service-{service_name}-labels')
+        config_labels = get_config_labels(namespace, f'service-{service_name}-labels', cli)
         kind = config_labels['MLAD.PROJECT.SERVICE.KIND']
-        return service_name, namespace, kind, targets
+        controller = config_labels['MLAD.PROJECT.SERVICE.CONTROLLER']
+        return service_name, namespace, controller, targets
 
     service_to_check = []
     for service in services:
-        service_name, namespace, kind, _ = _get_service_info(service)
-        service_to_check.append((service_name, namespace, kind, _))
+        service_name, namespace, controller, _ = _get_service_info(service)
+        service_to_check.append((service_name, namespace, controller, _))
 
     # For check service deleted
     collector = Collector()
@@ -757,19 +906,22 @@ def remove_services(cli, services, disconnHandler=None, timeout=0xFFFF, stream=F
         disconnHandler.add_callback(lambda: monitor.stop())
 
     for service in service_to_check:
-        service_name, namespace, kind, _ = service
+        service_name, namespace, controller, _ = service
         #print(f"Stop {service_name}...")
-        ret = api.delete_namespaced_service(service_name, namespace)
-        if kind == 'job':
-            ret = _delete_job(cli, service_name, namespace)
-        elif kind == 'rc':
-            ret = _delete_replication_controller(cli, service_name, namespace)
-
         try:
-            #check ingress exists
-            ingress = network_api.list_namespaced_ingress(namespace)
-            if service_name in ingress.items:
-                ingress_ret = network_api.delete_namespaced_ingress(service_name, namespace)
+            if controller == 'Job':
+                ret = _delete_job(cli, service_name, namespace)
+            elif controller == 'Deployment':
+                ret = _delete_deployment(cli, service_name, namespace)
+
+            if get_deployed_service(cli, namespace, service_name):
+                api.delete_namespaced_service(service_name, namespace)
+
+            ingress = network_api.list_namespaced_ingress(
+                namespace, label_selector=f'MLAD.PROJECT.SERVICE={service_name}').items
+            if len(ingress) > 0:
+                ingress_name = ingress[0].metadata.name
+                ingress_ret = network_api.delete_namespaced_ingress(ingress_name, namespace)
         except ApiException as e:
             print("Exception when calling ExtensionsV1beta1Api->delete_namespaced_ingress: %s\n" % e)
 
@@ -785,8 +937,8 @@ def remove_services(cli, services, disconnHandler=None, timeout=0xFFFF, stream=F
         for service in services:
             service_removed = False
             name, namespace, kind = _get_service_info(service)
-            if not get_service_from_kind(cli, name, namespace, kind) and \
-                    not get_service(cli, service_name=name, namespace=namespace):
+            if not get_service_from_controller(cli, name, namespace, controller) and \
+                    not get_service(name, namespace, cli):
                 service_removed = True
             else:
                 service_removed = False
@@ -845,6 +997,7 @@ def get_node(node_key, cli = DEFAULT_CLI):
         #print(f'Cannot find node "{node_key}"', file=sys.stderr)
         raise exceptions.NotFound(f'Cannot find node "{node_key}"')
 
+
 def inspect_node(node):
     if not isinstance(node, client.models.v1_node.V1Node):
         raise TypeError('Parameter is not valid type.')
@@ -871,6 +1024,7 @@ def inspect_node(node):
         'engine_version': engine_version,
         'status': {'State': state, 'Addr':addr},
     }
+
 
 def enable_node(node_key, cli = DEFAULT_CLI):
     if not isinstance(cli, client.api_client.ApiClient):
@@ -952,14 +1106,19 @@ def remove_node_labels(node_key, cli = DEFAULT_CLI, *keys):
             raise exceptions.APIError(msg, status)
 
 
-def scale_service(cli, service, scale_spec):
+def scale_service(service, scale_spec, cli=DEFAULT_CLI):
+    controller = None
     if not isinstance(cli, client.api_client.ApiClient):
         raise TypeError('Parameter is not valid type.')
+    if isinstance(service, client.models.v1_deployment.V1Deployment):
+        controller = 'Deployment'
+    elif isinstance(service, client.models.v1_job.V1Job):
+        controller = 'Job'
+    else: raise TypeError('Parameter is not valid type.')
     name = service.metadata.name
     namespace = service.metadata.namespace
-    config_labels = get_config_labels(cli, service, f'service-{name}-labels')
-    kind = config_labels['MLAD.PROJECT.SERVICE.KIND']
-    if kind == 'job':
+
+    if controller == 'Job':
         api = client.BatchV1Api(cli)
         body = {
             "spec": {
@@ -968,16 +1127,17 @@ def scale_service(cli, service, scale_spec):
         }
         ret = api.patch_namespaced_job(
             name=name, namespace=namespace, body=body)
-    elif kind == 'rc':
-        api = client.CoreV1Api(cli)
+    elif controller == 'Deployment':
+        api = client.AppsV1Api(cli)
         body = {
             "spec": {
                 "replicas": scale_spec
             }
         }
-        ret = api.patch_namespaced_replication_controller_scale(
+        ret = api.patch_namespaced_deployment_scale(
             name=name, namespace=namespace, body=body)
     return ret
+
 
 def container_logs(cli, project_key, tail='all', follow=False, timestamps=False):
     instances = cli.containers.list(all=True, filters={'label': f'MLAD.PROJECT={project_key}'})
@@ -991,14 +1151,16 @@ def container_logs(cli, project_key, tail='all', follow=False, timestamps=False)
     else:
         print('Cannot find running containers.', file=sys.stderr)
 
-def get_service_with_names_or_ids(cli, project_key, names_or_ids=[]):
+
+def get_service_with_names_or_ids(project_key, names_or_ids=[], cli=DEFAULT_CLI):
     # get running services with service or pod name
     api = client.CoreV1Api(cli)
-    services = get_services(cli, project_key)
+    services = get_services(project_key, cli=cli)
     namespace = get_project_network(cli, project_key=project_key).metadata.name
 
     selected = []
-    sources = [(_['name'], list(_['tasks'].keys())) for _ in [inspect_service(cli, _) for _ in services.values()]]
+    sources = [(_['name'], list(_['tasks'].keys())) for _ in
+               [inspect_service(_, cli) for _ in services.values()]]
     if names_or_ids:
         selected = []
         for _ in sources:
@@ -1033,10 +1195,11 @@ def get_service_with_names_or_ids(cli, project_key, names_or_ids=[]):
 
     return targets
 
-def get_project_logs(cli, project_key, tail='all', follow=False, timestamps=False,
-                     selected=False, disconnHandler=None, targets=[]):
+
+def get_project_logs(project_key, tail='all', follow=False, timestamps=False,
+                     selected=False, disconnHandler=None, targets=[], cli=DEFAULT_CLI):
     api = client.CoreV1Api(cli)
-    services = get_services(cli, project_key)
+    services = get_services(project_key, cli=cli)
     namespace = get_project_network(cli, project_key=project_key).metadata.name
 
     handler = LogHandler(cli)
@@ -1063,7 +1226,8 @@ def get_project_logs(cli, project_key, tail='all', follow=False, timestamps=Fals
     else:
         print('Cannot find running containers.', file=sys.stderr)
 
-def create_ingress(cli, namespace, service_name, port, base_path='/', rewrite=False):
+
+def create_ingress(cli, namespace, service_name, ingress_name, port, base_path='/', rewrite=False):
     api = client.NetworkingV1beta1Api(cli)
     annotations = {
         "kubernetes.io/ingress.class": "nginx",
@@ -1078,7 +1242,8 @@ def create_ingress(cli, namespace, service_name, port, base_path='/', rewrite=Fa
     body = client.NetworkingV1beta1Ingress(
         api_version="networking.k8s.io/v1beta1",
         kind="Ingress",
-        metadata=client.V1ObjectMeta(name=service_name, annotations=annotations),
+        metadata=client.V1ObjectMeta(name=ingress_name, annotations=annotations,
+                                     labels={'MLAD.PROJECT.SERVICE':service_name}),
         spec=client.NetworkingV1beta1IngressSpec(
             rules=[client.NetworkingV1beta1IngressRule(
                 #host="example.com",
@@ -1101,6 +1266,7 @@ def create_ingress(cli, namespace, service_name, port, base_path='/', rewrite=Fa
         body=body
     )
 
+
 def parse_mem(str_mem):
     # Ki to Mi
     if str_mem.endswith('Ki'):
@@ -1110,6 +1276,7 @@ def parse_mem(str_mem):
         mem = float(str_mem)
     return mem
 
+
 def parse_cpu(str_cpu):
     # nano to core
     if str_cpu.endswith('n'):
@@ -1118,6 +1285,7 @@ def parse_cpu(str_cpu):
         # TODO Other units may need to be considered
         cpu = float(str_cpu)
     return cpu
+
 
 def get_node_resources(node, cli = None):
     if cli is None :
@@ -1165,11 +1333,12 @@ def get_node_resources(node, cli = None):
         'gpu': {'capacity': gpu, 'used': used_gpu, 'allocatable': gpu-used_gpu},
     }
 
-def get_project_resources(cli, project_key):
+
+def get_project_resources(project_key, cli=DEFAULT_CLI):
     api = client.CustomObjectsApi(cli)
     v1_api = client.CoreV1Api(cli)
     res = {}
-    services = get_services(cli, project_key)
+    services = get_services(project_key, cli=cli)
 
     def gpu_usage(pod):
         used = 0
@@ -1209,6 +1378,7 @@ def get_project_resources(cli, project_key):
 
         res[name] = {'mem': resource['mem'], 'cpu': resource['cpu'], 'gpu': resource['gpu']}
     return res
+
 
 if __name__ == '__main__':
     cli = get_api_client()

--- a/python/mlad/core/kubernetes/monitor.py
+++ b/python/mlad/core/kubernetes/monitor.py
@@ -52,7 +52,7 @@ class DelMonitor(Thread):
                     if pod in services[service]:
                         services[service].remove(pod)
                         if not services[service]:
-                            msg = f"Service {service} removed."
+                            msg = f'Service \'{service}\' removed.'
                             self.collector.queue.put({'result': 'succeed', 'stream': msg})
                         all_targets.remove(pod)
                         if not all_targets:

--- a/python/mlad/service/libs/utils.py
+++ b/python/mlad/service/libs/utils.py
@@ -1,6 +1,6 @@
 import sys
 import os
-from mlad.core.default import config as service_config
+from mlad.core.default.config import service_config
 from mlad.cli import config as config_core
 
 

--- a/python/mlad/service/models/service.py
+++ b/python/mlad/service/models/service.py
@@ -1,48 +1,95 @@
-from typing import List, Optional
+import json
+from typing import List, Optional, Union
 from pydantic import BaseModel
 
-class RestartPolicy(BaseModel):
-    condition: Optional[str]=None
-    delay: Optional[int]=None
-    max_attempts: Optional[int]=None
-    window: Optional[int]=None
 
 class Quota(BaseModel):
-    cpus: Optional[int]=None
-    gpus: Optional[int]=None
-    mems: Optional[str]=None
+    cpu: Optional[int]=None
+    gpu: Optional[int]=None
+    mem: Optional[str]=None
 
-class Deploy(BaseModel):
-    quota: Optional[Quota]= None
-    constraints: Optional[dict]=None
-    restart_policy: Optional[RestartPolicy]=None
-    replicas: Optional[int]=None
 
-class Service(BaseModel):
-    name: str #service_name
-    # Deprecated: decide type by restart policy.
-    #type: Optional[str] = 'job' #job or rc
+class Ingress(BaseModel):
+    name: str = None
+    rewritePath: bool = True
+    port: str = None
+
+
+class Component(BaseModel):
+    kind = 'Component'
+    name: str
     image: Optional[str] = None
     env: Optional[dict] = None
-    depends: Optional[list] = None
+    ports: Optional[list] = None
     command: Optional[str] = None
-    arguments: Optional[str] = None
-    #labels: dict
-    ports: Optional[list]=None #k8s Required
-    deploy: Optional[Deploy]=None
-    # For Plugin
-    service_type: Optional[str] = None
-    expose: Optional[int] = None
+    args: Optional[str] = None
+    ports: Optional[list] = None
+    mounts: Optional[list] = None
+    ingress: Optional[Ingress] = None
+
+
+class Constraint(BaseModel):
+    hostname: Optional[str] = None
+    label: Optional[dict] = None
+
+
+class AppBase(Component):
+    kind = 'App'
+    constraints: Optional[Constraint] = None
+
+
+class AdvancedBase(AppBase):
+    resources: Optional[dict] = None
+
+
+class App(AppBase):
+    restartPolicy: Optional[str] = 'never'
+    scale: Optional[int] = 1
+    quota: Optional[Quota] = None
+
+
+class JobRunSpec(BaseModel):
+    restart_policy: Optional[str] = 'never'
+    parallelism: Optional[int] = 1
+    completion: Optional[int] = 1
+
+
+class Job(AdvancedBase):
+    kind = 'Job'
+    runSpec: Optional[JobRunSpec] = None
+
+
+class AutoScaler(BaseModel):
+    enable: Optional[bool] = False
+    min: Optional[int] = 1
+    max: Optional[int] = 1
+    metrics: Optional[list] = None
+
+
+class SerivceRunSpec(BaseModel):
+    replicas: Optional[int] = 1
+    autoscaler: Optional[AutoScaler] = None
+
+
+class Service(AdvancedBase):
+    kind = 'Service'
+    runSpec: Optional[SerivceRunSpec] = None
 
 
 class CreateRequest(BaseModel):
-    services: List[Service]
-    
+    services: List[dict]
+
     @property
     def json(self):
-        import json
         targets = dict()
         for _ in self.services:
+            kind = _['kind']
+            if kind == 'App':
+                _ = App(**_)
+            elif kind == 'Job':
+                _ = Job(**_)
+            elif kind == 'Service':
+                _ = Service(**_)
             service = json.loads(_.json())
             targets[_.name]=service
             del targets[_.name]['name']

--- a/python/mlad/service/models/service.py
+++ b/python/mlad/service/models/service.py
@@ -49,7 +49,7 @@ class App(AppBase):
 
 
 class JobRunSpec(BaseModel):
-    restart_policy: Optional[str] = 'never'
+    restartPolicy: Optional[str] = 'never'
     parallelism: Optional[int] = 1
     completion: Optional[int] = 1
 

--- a/python/mlad/service/models/service.py
+++ b/python/mlad/service/models/service.py
@@ -21,8 +21,8 @@ class Component(BaseModel):
     image: Optional[str] = None
     env: Optional[dict] = None
     ports: Optional[list] = None
-    command: Optional[str] = None
-    args: Optional[str] = None
+    command: Optional[Union[list, str]] = None
+    args: Optional[Union[list, str]] = None
     ports: Optional[list] = None
     mounts: Optional[list] = None
     ingress: Optional[Ingress] = None

--- a/python/mlad/service/routers/node.py
+++ b/python/mlad/service/routers/node.py
@@ -17,10 +17,10 @@ logger = init_logger(__name__)
 def node_list(session: str = Header(None)):
     try:
         nodes = ctlr.get_nodes()
+        return list(nodes.keys())
     except Exception as e:
         logger.error(e)
         raise HTTPException(status_code=500, detail=exception_detail(e))
-    return list(nodes.keys())
 
 
 @router.get("/node/{node_id}")
@@ -28,13 +28,13 @@ def node_inspect(node_id:str, session: str = Header(None)):
     try:
         node = ctlr.get_node(node_id)
         inspects = ctlr.inspect_node(node)
+        return inspects
     except exception.NotFound as e:
         logger.error(e)
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
         logger.error(e)
         raise HTTPException(status_code=500, detail=exception_detail(e))
-    return inspects
 
 
 @router.get("/nodes/resource")
@@ -48,10 +48,10 @@ def node_resource(nodes: List[str] = Query(None)):
             name = node.metadata.name
             resource = ctlr.get_node_resources(node)
             res[name] = resource
+        return res
     except exception.NotFound as e:
         logger.error(e)
         raise HTTPException(status_code=400, detail=exception_detail(e))
     except Exception as e:
         logger.error(e)
         raise HTTPException(status_code=500, detail=exception_detail(e))
-    return res

--- a/python/mlad/service/routers/node.py
+++ b/python/mlad/service/routers/node.py
@@ -17,10 +17,10 @@ logger = init_logger(__name__)
 def node_list(session: str = Header(None)):
     try:
         nodes = ctlr.get_nodes()
-        return list(nodes.keys())
     except Exception as e:
         logger.error(e)
         raise HTTPException(status_code=500, detail=exception_detail(e))
+    return list(nodes.keys())
 
 
 @router.get("/node/{node_id}")
@@ -28,13 +28,13 @@ def node_inspect(node_id:str, session: str = Header(None)):
     try:
         node = ctlr.get_node(node_id)
         inspects = ctlr.inspect_node(node)
-        return inspects
     except exception.NotFound as e:
         logger.error(e)
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
         logger.error(e)
         raise HTTPException(status_code=500, detail=exception_detail(e))
+    return inspects
 
 
 @router.get("/nodes/resource")
@@ -48,10 +48,10 @@ def node_resource(nodes: List[str] = Query(None)):
             name = node.metadata.name
             resource = ctlr.get_node_resources(node)
             res[name] = resource
-        return res
     except exception.NotFound as e:
         logger.error(e)
         raise HTTPException(status_code=400, detail=exception_detail(e))
     except Exception as e:
         logger.error(e)
         raise HTTPException(status_code=500, detail=exception_detail(e))
+    return res

--- a/python/mlad/service/routers/service.py
+++ b/python/mlad/service/routers/service.py
@@ -43,12 +43,12 @@ def services_list(labels: List[str] = Query(None),
         services = ctlr.get_services(extra_filters=labels_dict)
         for service in services.values():
             inspect = ctlr.inspect_service(service)
-            inspects.append(inspect)    
+            inspects.append(inspect)
+        return {'inspects': inspects}
     except InvalidProjectError as e:
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=exception_detail(e))
-    return {'inspects': inspects}
 
 
 @router.get("/project/{project_key}/service")
@@ -72,11 +72,11 @@ def service_list(project_key:str,
         for service in services.values():
             inspect = ctlr.inspect_service(service)
             inspects.append(inspect)
+        return {'inspects': inspects}
     except InvalidProjectError as e:
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=exception_detail(e))
-    return {'inspects':inspects}
     #return [_.short_id for _ in services.values()]
 
 
@@ -90,6 +90,7 @@ def service_create(project_key:str, req:service.CreateRequest,
         if not network:
             raise InvalidProjectError(project_key)
         services = ctlr.create_services(network, targets)
+        return [ctlr.inspect_service(_) for _ in services]
     except InvalidProjectError as e:
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except APIError as e:
@@ -97,7 +98,6 @@ def service_create(project_key:str, req:service.CreateRequest,
     except Exception as e:
         raise HTTPException(status_code=500, detail=exception_detail(e))
     #return [_.metadata.uid for _ in services]
-    return [ctlr.inspect_service(_) for _ in services]
 
 
 @router.get("/project/{project_key}/service/{service_name}")
@@ -109,11 +109,11 @@ def service_inspect(project_key:str, service_name:str,
         service = ctlr.get_service(service_name, namespace)
         if _check_project_key(key, service):
             inspect = ctlr.inspect_service(service)
+        return inspect
     except InvalidServiceError as e:
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=exception_detail(e))
-    return inspect
 
 
 @router.get("/project/{project_key}/service/{service_name}/tasks")
@@ -125,11 +125,11 @@ def service_tasks(project_key:str, service_name:str,
         service = ctlr.get_service(service_name, namespace)
         if _check_project_key(key, service):
             tasks = ctlr.inspect_service(service)['tasks']
+        return tasks
     except InvalidServiceError as e:
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=exception_detail(e))
-    return tasks
 
 
 @router.put("/project/{project_key}/service/{service_name}/scale")

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,8 @@ def main():
         'psutil>=5.8.0,<5.9.0',
         'omegaconf>=2.0.6,<3.0.0',
         'kubernetes>=12.0.0,<13.0.0',
-        'PyJWT>=2.1.0,<3.0.0'
+        'PyJWT>=2.1.0,<3.0.0',
+        'Cerberus>=1.3.0,<1.4.0'
       ],
       entry_points='''
         [console_scripts]

--- a/scripts/mlad-service-beta.yaml
+++ b/scripts/mlad-service-beta.yaml
@@ -8,8 +8,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: controller-role
 rules:
-- apiGroups: ["", "apps", "batch", "extensions", "rbac.authorization.k8s.io", "networking.k8s.io", "metrics.k8s.io"]
-  resources: ["nodes", "namespaces", "services", "pods", "pods/log", "replicationcontrollers", "deployments", "replicaset", "jobs", "configmaps", "secrets", "events", "rolebindings", "ingresses", "podmetrics"]
+- apiGroups: ["", "apps", "batch", "extensions", "rbac.authorization.k8s.io", "networking.k8s.io",
+              "metrics.k8s.io", "autoscaling"]
+  resources: ["nodes", "namespaces", "services", "pods", "pods/log", "replicationcontrollers",
+              "deployments", "replicaset", "jobs", "configmaps", "secrets", "events", "rolebindings",
+              "ingresses", "podmetrics", "horizontalpodautoscalers"]
   verbs: ["get", "watch", "list", "create", "update", "delete", "patch", "deletecollection"]
 ---
 kind: ClusterRoleBinding

--- a/scripts/mlad-service.yaml
+++ b/scripts/mlad-service.yaml
@@ -8,8 +8,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: controller-role
 rules:
-- apiGroups: ["", "apps", "batch", "extensions", "rbac.authorization.k8s.io", "networking.k8s.io", "metrics.k8s.io"]
-  resources: ["nodes", "namespaces", "services", "pods", "pods/log", "replicationcontrollers", "deployments", "replicaset", "jobs", "configmaps", "secrets", "events", "rolebindings", "ingresses", "podmetrics"]
+- apiGroups: ["", "apps", "batch", "extensions", "rbac.authorization.k8s.io", "networking.k8s.io",
+              "metrics.k8s.io", "autoscaling"]
+  resources: ["nodes", "namespaces", "services", "pods", "pods/log", "replicationcontrollers",
+              "deployments", "replicaset", "jobs", "configmaps", "secrets", "events", "rolebindings",
+              "ingresses", "podmetrics", "horizontalpodautoscalers"]
   verbs: ["get", "watch", "list", "create", "update", "delete", "patch", "deletecollection"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
Resolve #49 
Resolve #29

- 변경된 schema 에 맞춰, kind에 따라 app (기존 service)들을 실행할 수 있도록 project/service수정
    1. mlad service api와 controller에서 service 관련 api들이 거의 전부 수정되었습니다. service 생성시 kind에 따라 _create api 들을 옵션에 맞게 사용합니다.
    2. 내부적으로 실제 app의 kind(App, Service, Job) 은 KIND, app을 구동하는 kube kind는 CONTROLLER 라는 변수명(+label명) 을 사용합니다 
    3. 지금은 deploy를 고려하지 않는데, 이후에 project 와 deploy를 구별하기 위해 type등을 추가할 예정입니다. 
    4. mlad project init 변경 (변경된 schema 적용)O
    5. examples/project 예제 동작O
    
- validator 적용 
    1. 모듈 위치가 조금 고민되네요. editor도 추가될 예정이라 일단 임시로 저렇게 두었습니다. 
    2. project가 직접적으로 사용하는건 project_validator.validate
    3. ~~현재 validator error msg가 문제 파악이 어려운 이슈가 있어서 이후 수정이 필요할 것 같습니다. (일단 지금은 출력)~~
    4. validator가 추가되면서 기존에 default format들 (mlad/core/default/*) 가 불필요하다고 생각되어 일단 사용하지 않습니다.

- run command 추가
    1. EX) `mlad run --no-build --env --quota cpu=1 --quota gpu=0 -- python main.py --a 1`
    2. 임의 이름의 app을 생성합니다.  이름을 어떻게 하는게 좋을까요?
 
TODO
- ~~Autoscaler test 를 추가적으로 할 예정입니다(동작은 합니다.)~~
- ~~validator에서 command/args type이 str -> [str, list]로 바뀌어서 내부 로직 수정할 예정입니다.~~
- controller 에서 DEFAULT_CLI 지정하는 부분 일부 수정했습니다. 아직 전부 반영안되었습니다...

**TEST CASE**
test 코드 구현 전이므로 예제(examples/project/*)를 통해 테스트를 진행할 수 있을 것 같습니다.
- app kind (None, App, Job, Service) 에 따른 service 생성 O
- restart policy 에 따른 App 생성 O
- ingress 생성 확인 O
- ports 추가시 service(k8s) 생성 확인 O
- resource 할당 확인 O
- scale 옵션 변경시 scale out 여부 확인 O
   - Job/Service일경우 runSpec
- constraints 지정시 node affinity 확인 O
- Service 의 autoscaler 동작 확인 ( 내부에서 autoscaler average_utilization을 60% 로 fix해놓았기때문에, service의 resource 사용량에 비해 resources 지정량이 충분히 모자라야 autoscale 되는 것을 확인할 수 있습니다.) o
- mount 옵션 확인 (hostpath 에 따른 mount만 지원합니다.) O -> validator 에서 / 이 regex에 걸리는 이슈있음