### PR TITLE
Echo exception if the docker is not installed

### DIFF
--- a/python/mlad/cli/__init__.py
+++ b/python/mlad/cli/__init__.py
@@ -8,5 +8,5 @@ def echo_exception(func):
         try:
             func(*args, **kwargs)
         except Exception as e:
-            click.echo(e)
+            click.echo(f'{e.__class__.__name__}: {e}')
     return decorated

--- a/python/mlad/cli/board_cli.py
+++ b/python/mlad/cli/board_cli.py
@@ -1,53 +1,49 @@
 import click
 
 from mlad.cli import board
+from . import echo_exception
 
 
 @click.command()
+@echo_exception
 def activate():
     """Activate MLAD board."""
-    try:
-        click.echo('Start running MLAD board.')
-        board.activate()
-        click.echo('Successfully activate MLAD board.')
-    except Exception as e:
-        click.echo(e)
+    click.echo('Start running MLAD board.')
+    board.activate()
+    click.echo('Successfully activate MLAD board.')
 
 
 @click.command()
+@echo_exception
 def deactivate():
     """Deactivate MLAD board and remove components."""
-    try:
-        click.echo('Start deactivating MLAD board.')
-        board.deactivate()
-        click.echo('Successfully deactivate MLAD board.')
-    except Exception as e:
-        click.echo(e)
+    click.echo('Start deactivating MLAD board.')
+    board.deactivate()
+    click.echo('Successfully deactivate MLAD board.')
 
 
 @click.command()
 @click.option('--file-path', '-f', required=True, help='The file path of the component')
 @click.option('--no-build', is_flag=True, help='Don\'t build the base image')
+@echo_exception
 def install(file_path: str, no_build: bool):
     """Install a component and attach it to MLAD board."""
-    try:
-        click.echo(f'Read the component spec from {file_path or "./mlad-project.yml"}.')
-        board.install(file_path, no_build)
-        click.echo('The component installation is complete.')
-    except Exception as e:
-        click.echo(e)
+    click.echo(f'Read the component spec from {file_path or "./mlad-project.yml"}.')
+    board.install(file_path, no_build)
+    click.echo('The component installation is complete.')
+
 
 @click.command()
 @click.argument('name', required=True)
+@echo_exception
 def uninstall(name: str):
     """Uninstall the component and remove it from MLAD board."""
-    try:
-        board.uninstall(name)
-        click.echo(f'The component [{name}] is uninstalled')
-    except Exception as e:
-        click.echo(e)
+    board.uninstall(name)
+    click.echo(f'The component [{name}] is uninstalled')
+
 
 @click.command()
+@echo_exception
 def ls():
     """List installed components"""
     board.list()

--- a/python/mlad/cli/exceptions.py
+++ b/python/mlad/cli/exceptions.py
@@ -70,3 +70,9 @@ class CannotBuildComponentError(Exception):
 
     def __str__(self):
         return 'The component spec does not have `workspace` property to build an image.'
+
+
+class DockerNotFoundError(Exception):
+
+    def __str__(self):
+        return 'Need to install the docker daemon.'


### PR DESCRIPTION
Resolve #26 

원래는 `mlad config init`을 했을 때 `board.py`의 `docker.from_env`가 불리면서 stacktrace 등 오류가 발생했었습니다. 따라서 docker initialize 시점을 바꾸고 `DockerNotFoundError`를 올바르게 발생시키도록 변경하였습니다.