### PR TITLE
Update timeout if streaming requests are sent

### DIFF
--- a/python/mlad/api/base.py
+++ b/python/mlad/api/base.py
@@ -15,6 +15,8 @@ class APIBase:
     def _get(self, path: str, params: Optional[Dict] = None,
              raw: bool = False, stream: bool = False, timeout: int = 30):
         url = f'{self.baseurl}{path}'
+        if stream:
+            timeout = 1e4
         res = requests.get(url=url, headers=self.headers, params=params,
                            timeout=timeout, stream=stream)
         self.raise_error(res)
@@ -23,6 +25,8 @@ class APIBase:
     def _post(self, path: str, params: Optional[Dict] = None, body: Optional[Dict] = None,
               raw: bool = False, stream: bool = False, timeout: int = 30):
         url = f'{self.baseurl}{path}'
+        if stream:
+            timeout = 1e4
         res = requests.post(url=url, headers=self.headers, params=params, json=body,
                             timeout=timeout, stream=stream)
         self.raise_error(res)
@@ -31,6 +35,8 @@ class APIBase:
     def _delete(self, path: str, params: Optional[Dict] = None, body: Optional[Dict] = None,
                 raw: bool = False, stream: bool = False, timeout: int = 30):
         url = f'{self.baseurl}{path}'
+        if stream:
+            timeout = 1e4
         res = requests.delete(url=url, headers=self.headers, params=params, json=body,
                               timeout=timeout, stream=stream)
         self.raise_error(res)
@@ -39,6 +45,8 @@ class APIBase:
     def _put(self, path: str, params: Optional[Dict] = None, body: Optional[Dict] = None,
              raw: bool = False, stream: bool = False, timeout: int = 30):
         url = f'{self.baseurl}{path}'
+        if stream:
+            timeout = 1e4
         res = requests.put(url=url, headers=self.headers, params=params, json=body,
                            timeout=timeout, stream=stream)
         self.raise_error(res)

--- a/python/mlad/api/exception.py
+++ b/python/mlad/api/exception.py
@@ -28,10 +28,8 @@ class NotFound(APIError):
 class ProjectNotFound(NotFound):
     pass
 
-
 class ServiceNotFound(NotFound):
     pass
-
 
 class InvalidLogRequest(NotFound):
     pass

--- a/python/mlad/cli/project.py
+++ b/python/mlad/cli/project.py
@@ -696,22 +696,15 @@ def down_force(services, no_dump):
 def logs(tail, follow, timestamps, names_or_ids):
     project_key = utils.project_key(utils.get_workspace())
     # Block not running.
-    try:
-        API.project.inspect(project_key)
-        logs = API.project.log(project_key, tail, follow, timestamps, names_or_ids)
-    except NotFound:
-        print('Cannot find running service.', file=sys.stderr)
-        sys.exit(1)
+    API.project.inspect(project_key)
+
+    logs = API.project.log(project_key, tail, follow, timestamps, names_or_ids)
 
     colorkey = {}
-    try:
-        for _ in logs:
-            if '[Ignored]' in _['stream']:
-                continue
-            _print_log(_, colorkey, 32, 20)
-    except APIError as e:
-        print(e)
-        sys.exit(1)
+    for _ in logs:
+        if '[Ignored]' in _['stream']:
+            continue
+        _print_log(_, colorkey, 32, 20)
 
 
 def scale(scales):

--- a/python/mlad/cli/project_cli.py
+++ b/python/mlad/cli/project_cli.py
@@ -6,6 +6,7 @@ from mlad.cli import project
 from mlad.cli.libs import utils
 from mlad.cli.autocompletion import *
 from mlad.cli.libs.auth import auth_admin
+from . import echo_exception
 
 
 # mlad project init
@@ -73,7 +74,8 @@ def down(services, no_dump):
 @click.option('--tail', default='all', help='Number of lines to show from the end of logs (default "all")')
 @click.option('--timestamps', '-t', is_flag=True, help='Show timestamp with logs')
 @click.option('--follow', '-f', is_flag=True, help='Follow log output')
-@click.argument('SERVICES|TASKS', nargs=-1, autocompletion=get_running_services_tasks_completion)
+@click.argument('SERVICES|TASKS', nargs=-1)
+@echo_exception
 def logs(tail, follow, timestamps, **kwargs):
     '''Show current project logs deployed on cluster'''
     filters = kwargs.get('services|tasks')

--- a/python/mlad/service/exception.py
+++ b/python/mlad/service/exception.py
@@ -34,7 +34,7 @@ class TokenError(Exception):
 
 
 def exception_detail(e):
-    exception=e.__class__.__name__
+    exception = e.__class__.__name__
     msg = str(e)
 
     if 'NotFound' in exception:

--- a/python/mlad/service/routers/project.py
+++ b/python/mlad/service/routers/project.py
@@ -60,9 +60,9 @@ def projects(extra_labels: str = '', session: str = Header(None)):
 
 
 @router.get("/project/{project_key}")
-def project_inspect(project_key:str, session: str = Header(None)):
+def project_inspect(project_key: str, session: str = Header(None)):
     try:
-        key = str(project_key).replace('-','')
+        key = str(project_key).replace('-', '')
         network = ctlr.get_project_network(project_key=key)
         if not network:
             raise InvalidProjectError(project_key)
@@ -99,7 +99,7 @@ def project_remove(project_key:str, session: str = Header(None)):
 
 
 @router.get("/project/{project_key}/logs")
-def project_log(project_key: str, tail:str = Query('all'),
+def project_log(project_key: str, tail: str = Query('all'),
                 follow: bool = Query(False),
                 timestamps: bool = Query(False),
                 names_or_ids: list = Query(None),
@@ -107,7 +107,7 @@ def project_log(project_key: str, tail:str = Query('all'),
 
     selected = True if names_or_ids else False
     try:
-        key = str(project_key).replace('-','')
+        key = str(project_key).replace('-', '')
         network = ctlr.get_project_network(project_key=key)
         if not network:
             raise InvalidProjectError(project_key)
@@ -124,21 +124,23 @@ def project_log(project_key: str, tail:str = Query('all'),
         class disconnectHandler:
             def __init__(self):
                 self._callbacks = []
+
             def add_callback(self, callback):
                 self._callbacks.append(callback)
+
             async def __call__(self):
                 for cb in self._callbacks:
                     cb()
+
         handler = disconnectHandler()
 
         logs = ctlr.get_project_logs(key, tail, follow, timestamps, selected, handler, targets)
 
-
         def get_logs(logs):
             for _ in logs:
-                _['stream']=_['stream'].decode()
+                _['stream'] =_['stream'].decode()
                 if timestamps:
-                    _['timestamp']=str(_['timestamp'])
+                    _['timestamp'] = str(_['timestamp'])
                 yield json.dumps(_)
 
         return StreamingResponse(get_logs(logs), background=handler)


### PR DESCRIPTION
Resolves #72 

제가 API 기능을 추가하면 timeout을 넣었는데 로그가 30초 이상 발생하지 않으면 exception이 발생하는 오류였습니다.
따라서 `stream=True`인 경우에는 timeout을 길게 잡도록 수정했습니다.

Stack trace가 크게 발생하는 경우는 catch를 하지 않는 exception이 발생했기 때문이며 모든 exception을 표기 할 수 있도록 전체적인 exception 로직을 수정했습니다. 현재는 `logs` 기능에만 적용했는데 추후에 다른 기능들에도 확장이 필요합니다.