### PR TITLE
Add deploy cli serve, kill & Remove project key uuid

### DIFF
--- a/python/mlad/cli/__main__.py
+++ b/python/mlad/cli/__main__.py
@@ -1,5 +1,6 @@
 import click
 import copy
+
 from mlad import __version__
 from mlad.cli import config_cli as config
 from mlad.cli import image_cli as image
@@ -8,6 +9,7 @@ from mlad.cli import node_cli as node
 from mlad.cli import context_cli as context
 from mlad.cli import board_cli as board
 from mlad.cli import train_cli as train
+from mlad.cli import deploy_cli as deploy
 from mlad.cli.autocompletion import get_project_file_completion
 from mlad.cli.libs.auth import auth_admin
 from mlad.cli.exceptions import ContextNotFoundError
@@ -60,6 +62,7 @@ else:
     main.add_command(image.cli, 'image')
     main.add_command(project.cli, 'project')
     main.add_command(train.cli, 'train')
+    main.add_command(deploy.cli, 'deploy')
     main.add_command(board.cli, 'board')
     main.add_command(node.admin_cli if auth_admin() else node.cli, 'node')
 

--- a/python/mlad/cli/deploy.py
+++ b/python/mlad/cli/deploy.py
@@ -58,10 +58,11 @@ def serve(file: Optional[str]):
 
     # Push image
     yield f'Upload the image to the registry [{registry_address}]...'
-    docker_ctlr.push_image(image_tag)
+    for line in docker_ctlr.push_image(image_tag):
+        yield line
 
     # Create a project
-    yield 'Deploy services to the cluster...'
+    yield 'Deploy applications to the cluster...'
     credential = docker_ctlr.obtain_credential()
     extra_envs = config_core.get_env()
     lines = API.project.create(base_labels, extra_envs, credential=credential, allow_reuse=False)

--- a/python/mlad/cli/deploy.py
+++ b/python/mlad/cli/deploy.py
@@ -52,7 +52,7 @@ def serve(file: Optional[str]):
     image = images[0]
 
     # Re-tag the image
-    registry_address = _get_registry_address(config)
+    registry_address = utils.get_registry_address(config)
     image_tag = f'{registry_address}/{image_tag}'
     image.tag(image_tag)
     base_labels['MLAD.PROJECT.IMAGE'] = image_tag
@@ -106,12 +106,3 @@ def kill(project_key: str, no_dump: bool):
     stream = down(None, project_key, no_dump)
     for msg in stream :
         yield msg
-
-
-def _get_registry_address(config: context.Context):
-    parsed = utils.parse_url(config.docker.registry.address)
-    registry_address = parsed['address']
-    namespace = config.docker.registry.namespace
-    if namespace is not None:
-        registry_address += f'/{namespace}'
-    return registry_address

--- a/python/mlad/cli/deploy_cli.py
+++ b/python/mlad/cli/deploy_cli.py
@@ -1,0 +1,44 @@
+import click
+from typing import Optional, Dict
+
+from mlad.cli import deploy
+from mlad.cli.libs import utils
+
+from . import echo_exception
+
+
+# mlad deploy serve
+# mlad deploy kill
+
+
+@click.command()
+@click.option('--file', '-f', default=None, help=(
+    'Specify an alternate project file\t\t\t\n'
+    f'Same as {utils.PROJECT_FILE_ENV_KEY} in environment variable')
+)
+@echo_exception
+def serve(file: Optional[str]):
+    '''Deploy and run a deploy object on the cluster.'''
+    for line in deploy.serve(file):
+        click.echo(line)
+
+
+@click.command()
+@click.argument('project-key', required=True)
+@click.option('--no-dump', is_flag=True,
+              help='Save the log before shutting down the services')
+@echo_exception
+def kill(project_key: str, no_dump: bool):
+    '''Stop and remove the train object on the cluster.'''
+    for line in deploy.kill(project_key, no_dump):
+        click.echo(line)
+
+
+@click.group('deploy')
+def cli():
+    '''Related to the deploy objects'''
+    pass
+
+
+cli.add_command(serve)
+cli.add_command(kill)

--- a/python/mlad/cli/exceptions.py
+++ b/python/mlad/cli/exceptions.py
@@ -94,3 +94,13 @@ class ProjectAlreadyExistError(Exception):
 
     def __str__(self):
         return f'Failed to create a project: [{self.project_key}] already exists.'
+
+
+class InvalidProjectKindError(Exception):
+
+    def __init__(self, kind: str, command: str = 'train'):
+        self.kind = kind
+        self.command = command
+
+    def __str__(self):
+        return f'Only kind "{self.kind}" is invalid for "{self.command}" command.'

--- a/python/mlad/cli/image.py
+++ b/python/mlad/cli/image.py
@@ -75,10 +75,10 @@ def build(quiet: bool, no_cache: bool, pull: bool):
     version = base_labels['MLAD.PROJECT.VERSION']
     image_tag = base_labels['MLAD.PROJECT.IMAGE']
 
-    workspace = manifest['workspace']
+    workspace = project['workspace']
     # For the workspace kind
     if workspace['kind'] == 'Workspace':
-        payload = _obtain_workspace_payload(workspace, manifest['maintainer'])
+        payload = _obtain_workspace_payload(workspace, project['maintainer'])
     # For the dockerfile kind
     else:
         if 'dockerfile' in workspace:
@@ -91,7 +91,7 @@ def build(quiet: bool, no_cache: bool, pull: bool):
     dockerfile_info = tarfile.TarInfo('.dockerfile')
     dockerfile_info.size = len(payload)
     with tarfile.open(fileobj=tarbytes, mode='w:gz') as tar:
-        for name, arcname in utils.arcfiles(manifest['workdir'], workspace['ignores']):
+        for name, arcname in utils.arcfiles(project['workdir'], workspace['ignores']):
             tar.add(name, arcname)
         tar.addfile(dockerfile_info, io.BytesIO(payload.encode()))
     tarbytes.seek(0)
@@ -138,7 +138,7 @@ def _obtain_workspace_payload(workspace, maintainer):
         prep_docker_formats.append(template.format(SRC=prep[key]))
 
     commands = [f'"{item}"' for item in workspace['command'].split()] + \
-        [f'"{item}"' for item in workspace['arguments'].split()]
+        [f'"{item}"' for item in workspace['args'].split()]
 
     return DOCKERFILE.format(
         BASE=workspace['base'],

--- a/python/mlad/cli/image.py
+++ b/python/mlad/cli/image.py
@@ -4,14 +4,18 @@ import tarfile
 import json
 import urllib3
 import requests
-from mlad.core.docker import controller as ctlr
-from mlad.core.libs import utils as core_utils
+
 from mlad.cli import config as config_core
+from mlad.cli.validator import validators
 from mlad.cli.libs import utils
 from mlad.cli.Format import (
     DOCKERFILE, DOCKERFILE_ENV, DOCKERFILE_REQ_PIP, DOCKERFILE_REQ_APT,
     DOCKERFILE_REQ_ADD, DOCKERFILE_REQ_RUN, DOCKERFILE_REQ_APK, DOCKERFILE_REQ_YUM
 )
+
+from mlad.core.docker import controller as ctlr
+from mlad.core.libs import utils as core_utils
+from mlad.core.default import project as default_project
 
 PREP_KEY_TO_TEMPLATE = {
     'run': DOCKERFILE_REQ_RUN,
@@ -61,11 +65,12 @@ def list(all, tail):
 def build(quiet: bool, no_cache: bool, pull: bool):
     config = config_core.get()
     cli = ctlr.get_api_client()
-    manifest = utils.get_manifest()
+    project = utils.get_project(default_project)
+    project = validators.validate(project)
 
     # Generate Base Labels
     workspace_key = utils.get_workspace()
-    base_labels = core_utils.base_labels(workspace_key, config.session, manifest)
+    base_labels = core_utils.base_labels(workspace_key, config.session, project, build=True)
     project_key = base_labels['MLAD.PROJECT']
     version = base_labels['MLAD.PROJECT.VERSION']
     image_tag = base_labels['MLAD.PROJECT.IMAGE']

--- a/python/mlad/cli/libs/utils.py
+++ b/python/mlad/cli/libs/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import os
 import re
@@ -7,7 +9,7 @@ import socket
 import hashlib
 import itertools
 import jwt
-from typing import Dict, Optional
+from typing import Dict, Optional, TYPE_CHECKING
 from pathlib import Path
 from functools import lru_cache
 from urllib.parse import urlparse
@@ -17,6 +19,9 @@ from getpass import getuser
 from mlad.cli.libs.exceptions import InvalidURLError
 from mlad.core.default import project as project_default
 from mlad.cli.libs.auth import auth_admin
+
+if TYPE_CHECKING:
+    from mlad.cli.context import Context
 
 
 HOME = str(Path.home())
@@ -111,7 +116,7 @@ def get_project(default_project):
 
     # replace workdir to abspath
     project_file = get_project_file()
-    #project = default_project(project)
+    project = default_project(project)
     path = project.get('workdir', './')
     if not os.path.isabs(path):
         project['workdir'] = os.path.normpath(
@@ -124,48 +129,8 @@ def get_project(default_project):
         print('Syntax Error: Project and service require a name to '
               'follow standard as defined in RFC1123.', file=sys.stderr)
         sys.exit(1)
+
     return project
-
-
-@lru_cache(maxsize=None)
-def manifest_file(ty='project'):
-    # Patch for WSL2 (/home/... -> /mnt/c/Users...)
-    if ty == 'project':
-        return os.path.realpath(os.environ.get('MLAD_PRJFILE', DEFAULT_PROJECT_FILE))
-    elif ty == 'plugin':
-        return os.path.realpath(DEFAULT_PLUGIN_FILE)
-
-
-@lru_cache(maxsize=None)
-def read_manifest(path):
-    if os.path.isfile(path):
-        manifest = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
-        return manifest
-    else:
-        return None
-
-
-def get_manifest() -> Dict:
-    default = project_default
-    manifest_path = os.path.realpath(os.environ.get('MLAD_PRJFILE', DEFAULT_PROJECT_FILE))
-    manifest = read_manifest(manifest_path)
-    if manifest is None:
-        print('Need to generate manifest file before.', file=sys.stderr)
-        print(f'$ {sys.argv[0]} --help', file=sys.stderr)
-        sys.exit(1)
-
-    # replace workdir to abspath
-    manifest = default(manifest)
-    path = manifest.get('workdir', './')
-    if not os.path.isabs(path):
-        manifest['workdir'] = os.path.normpath(
-            os.path.join(os.path.dirname(manifest_path), path)
-        )
-    if not check_podname_syntax(manifest['name']):
-        print('Syntax Error: Project(Component) and service require a name '
-              'to follow standard as defined in RFC1123.', file=sys.stderr)
-        sys.exit(1)
-    return manifest
 
 
 def print_table(data, no_data_msg=None, max_width=32, upper=True):
@@ -352,3 +317,12 @@ def parse_log(log: Dict, max_name_width: int = 32, len_short_id: int = 20) -> st
             return f'{timestamp} {name}: {msg}'
         else:
             return f'{name}: {msg}'
+
+
+def get_registry_address(config: Context):
+    parsed = parse_url(config.docker.registry.address)
+    registry_address = parsed['address']
+    namespace = config.docker.registry.namespace
+    if namespace is not None:
+        registry_address += f'/{namespace}'
+    return registry_address

--- a/python/mlad/cli/train.py
+++ b/python/mlad/cli/train.py
@@ -68,7 +68,7 @@ def up(file: Optional[str]):
         yield line
 
     # Create a project
-    yield 'Deploy services to the cluster...'
+    yield 'Deploy applications to the cluster...'
     credential = docker_ctlr.obtain_credential()
     extra_envs = config_core.get_env()
     lines = API.project.create(base_labels, extra_envs, credential=credential, allow_reuse=False)
@@ -94,7 +94,7 @@ def up(file: Optional[str]):
 
 
 def down(file: Optional[str], project_key: Optional[str], no_dump: bool):
-    _process_file(file)
+    utils.process_file(file)
     project_key_assigned = project_key is not None
     if project_key is None:
         project_key = utils.project_key(utils.get_workspace())
@@ -156,7 +156,7 @@ def down(file: Optional[str], project_key: Optional[str], no_dump: bool):
 
 
 def scale(scales: List[Tuple[str, int]], file: Optional[str], project_key: Optional[str]):
-    _process_file(file)
+    utils.process_file(file)
     if project_key is None:
         project_key = utils.project_key(utils.get_workspace())
 

--- a/python/mlad/cli/train.py
+++ b/python/mlad/cli/train.py
@@ -114,7 +114,7 @@ def down(file: Optional[str], project_key: Optional[str], no_dump: bool):
             try:
                 logs = API.project.log(project_key, timestamps=True, names_or_ids=[service_name])
                 for log in logs:
-                    log = _parse_log(log)
+                    log = utils.parse_log(log)
                     log_file.write(log)
             except InvalidLogRequest:
                 return f'There is no log in [{service_name}].'

--- a/python/mlad/cli/train.py
+++ b/python/mlad/cli/train.py
@@ -57,7 +57,7 @@ def up(file: Optional[str]):
     image = images[0]
 
     # Re-tag the image
-    registry_address = _get_registry_address(config)
+    registry_address = utils.get_registry_address(config)
     image_tag = f'{registry_address}/{image_tag}'
     image.tag(image_tag)
     base_labels['MLAD.PROJECT.IMAGE'] = image_tag
@@ -168,12 +168,3 @@ def scale(scales: List[Tuple[str, int]], file: Optional[str], project_key: Optio
         if target_name in service_names:
             API.service.scale(project_key, target_name, value)
             yield f'Scale updated [{target_name}] = {value}'
-
-
-def _get_registry_address(config: context.Context):
-    parsed = utils.parse_url(config.docker.registry.address)
-    registry_address = parsed['address']
-    namespace = config.docker.registry.namespace
-    if namespace is not None:
-        registry_address += f'/{namespace}'
-    return registry_address

--- a/python/mlad/cli/validator/validators.py
+++ b/python/mlad/cli/validator/validators.py
@@ -9,7 +9,6 @@ from mlad.cli.validator.exceptions import InvalidProjectYaml, InvalidComponentYa
 def validate(target):
     with open(f'{SCHEMA_PATH}/schema.yaml') as f:
         schema = load(f)
-
     v = Validator(schema, ordered=True)
     try:
         res = v.validate(target)

--- a/python/mlad/cli/validator/validators.py
+++ b/python/mlad/cli/validator/validators.py
@@ -17,6 +17,5 @@ def validate(target):
     if res:
         return v.normalized_by_order(target)
     else:
-        print(v.errors)
         raise InvalidProjectYaml(v.errors)
 

--- a/python/mlad/core/default/project.py
+++ b/python/mlad/core/default/project.py
@@ -3,6 +3,7 @@ from mlad.core.libs import utils
 
 workspace_default = {
     'apiVersion': 'v1',
+    'kind': 'Train',
     'name': 'Unknown',
     'version': '0.0.1',
     'maintainer': 'Unknown',
@@ -17,30 +18,45 @@ workspace_default = {
         },
         'ignores': ['**/.*'],
         'command': '',
-        'arguments': '',
+        'args': '',
     },
-    'ingress': {},
     'app': {}
 }
 
 dockerfile_default = {
     'apiVersion': 'v1',
+    'kind': 'Train',
     'name': 'Unknown',
     'version': '0.0.1',
     'maintainer': 'Unknown',
     'workdir': './',
     'workspace': {
         'kind': 'Dockerfile',
-        'ignores': ['**/.*'],
+        'filePath': 'Dockerfile',
+        'ignorePath': '.dockerignore',
     },
-    'ingress': {},
     'app': {}
 }
 
+buildscript_default = {
+    'apiVersion': 'v1',
+    'kind': 'Train',
+    'name': 'Unknown',
+    'version': '0.0.1',
+    'maintainer': 'Unknown',
+    'workdir': './',
+    'workspace': {
+        'kind': 'Buildscript',
+        'buildscript': 'FROM    python:latest',
+        'ignores': ['**/.*'],
+    },
+    'app': {}
+}
 
 def update(x):
     kind = x['workspace'].get('kind', 'Workspace')
-    return utils.update_obj(workspace_default if kind == 'Workspace' else dockerfile_default, x)
+    return utils.update_obj(workspace_default if kind == 'Workspace' else
+                            dockerfile_default if kind == 'Dockerfile' else buildscript_default, x)
 
 
 sys.modules[__name__] = lambda x: update(x)

--- a/python/mlad/core/kubernetes/controller.py
+++ b/python/mlad/core/kubernetes/controller.py
@@ -69,10 +69,12 @@ def get_project_network(cli=DEFAULT_CLI, **kwargs):
     if kwargs.get('project_key'):
         namespaces = api.list_namespace(label_selector=f"MLAD.PROJECT={kwargs.get('project_key')}")
     elif kwargs.get('project_id'):
-        namespaces = api.list_namespace(label_selector=f"MLAD.PROJECT.ID={kwargs.get('project_id')}")
+        namespaces = api.list_namespace(label_selector=
+                                        f"MLAD.PROJECT.ID={kwargs.get('project_id')}")
     elif kwargs.get('network_id'):
         all_namespaces = api.list_namespace(label_selector="MLAD.PROJECT")
-        namespaces = list(filter(lambda _: _.metadata.uid == kwargs.get('network_id'), all_namespaces))
+        namespaces = list(filter(lambda _: _.metadata.uid ==
+                                           kwargs.get('network_id'), all_namespaces))
     else:
         raise TypeError('At least one parameter is required.')
     if not namespaces.items:
@@ -125,12 +127,12 @@ def inspect_project_network(network, cli=DEFAULT_CLI):
         raise TypeError('Parameter is not valid type.')
     labels = get_labels(network)
     if network.metadata.deletion_timestamp:
-        return {'deleted': True, 'key': uuid.UUID(labels['MLAD.PROJECT'])}
+        return {'deleted': True, 'key': labels['MLAD.PROJECT']}
     created = network.metadata.creation_timestamp
     config_labels = get_config_labels(network, 'project-labels', cli)
     hostname, path = config_labels['MLAD.PROJECT.WORKSPACE'].split(':')
     return {
-        'key': uuid.UUID(labels['MLAD.PROJECT']),
+        'key': labels['MLAD.PROJECT'],
         'workspace': {
             'hostname': hostname,
             'path': path
@@ -228,7 +230,7 @@ def remove_project_network(network, timeout=0xFFFF, stream=False, cli=DEFAULT_CL
     def resp_stream():
         removed = False
         for tick in range(timeout):
-            if not get_project_network(cli, project_key=network_info['key'].hex):
+            if not get_project_network(cli, project_key=network_info['key']):
                 removed = True
                 break
             else:
@@ -245,7 +247,7 @@ def remove_project_network(network, timeout=0xFFFF, stream=False, cli=DEFAULT_CL
     if stream:
         return resp_stream()
     else:
-        return (not get_project_network(cli, project_key=network_info['key'].hex), (_ for _ in resp_stream()))
+        return (not get_project_network(cli, project_key=network_info['key']), (_ for _ in resp_stream()))
 
 
 # Manage services and tasks
@@ -424,7 +426,7 @@ def inspect_service(service, cli=DEFAULT_CLI):
     hostname, path = config_labels.get('MLAD.PROJECT.WORKSPACE', ':').split(':')
     pod_spec = service.spec.template.spec
     inspect = {
-        'key': uuid.UUID(config_labels['MLAD.PROJECT']) if config_labels.get(
+        'key': config_labels['MLAD.PROJECT'] if config_labels.get(
             'MLAD.VERSION') else '',
         'workspace': {
             'hostname': hostname,

--- a/python/mlad/core/libs/utils.py
+++ b/python/mlad/core/libs/utils.py
@@ -100,34 +100,34 @@ def change_key_style(dct):
 
 
 # Manage Project and Network
-def base_labels(workspace: str, session: str, manifest: Dict, build: bool = False):
+def base_labels(workspace: str, session: str, project: Dict, build: bool = False):
     # workspace = f"{hostname}:{workspace}"
     # Server Side Config 에서 가져올 수 있는건 직접 가져온다.
     username = get_username(session)
     key = project_key(workspace)
-    basename = f"{username}-{manifest['name']}-{key[:const.SHORT_LEN]}".lower()
+    basename = f"{username}-{project['name']}-{key[:const.SHORT_LEN]}".lower()
 
-    kind = manifest['kind']
+    kind = project['kind']
     if not build and kind == 'Deployment':
         deploy_key = shortuuid.uuid()
         key = f"{project_key(workspace)}-{deploy_key}"
-        basename = f"{username}-{manifest['name']}-{key[:const.SHORT_LEN]}-" \
+        basename = f"{username}-{project['name']}-{key[:const.SHORT_LEN]}-" \
                    f"{deploy_key[:const.SHORT_LEN]}".lower()
 
-    version = str(manifest['version']).lower()
-    default_image = f"{username}/{manifest['name']}-{key[:const.SHORT_LEN]}:{version}".lower()
+    version = str(project['version']).lower()
+    default_image = f"{username}/{project['name']}-{key[:const.SHORT_LEN]}:{version}".lower()
     labels = {
         'MLAD.VERSION': '1',
         'MLAD.PROJECT': key,
         'MLAD.PROJECT.WORKSPACE': workspace,
         'MLAD.PROJECT.USERNAME': username,
-        'MLAD.PROJECT.API_VERSION': manifest['apiVersion'],
-        'MLAD.PROJECT.NAME': manifest['name'].lower(),
-        'MLAD.PROJECT.MAINTAINER': manifest['maintainer'],
-        'MLAD.PROJECT.VERSION': str(manifest['version']).lower(),
+        'MLAD.PROJECT.API_VERSION': project['apiVersion'],
+        'MLAD.PROJECT.NAME': project['name'].lower(),
+        'MLAD.PROJECT.MAINTAINER': project['maintainer'],
+        'MLAD.PROJECT.VERSION': str(project['version']).lower(),
         'MLAD.PROJECT.BASE': basename,
         'MLAD.PROJECT.IMAGE': default_image,
         'MLAD.PROJECT.SESSION': session,
-        'MLAD.PROJECT.KIND': manifest['kind']
+        'MLAD.PROJECT.KIND': project['kind']
     }
     return labels

--- a/python/mlad/core/libs/utils.py
+++ b/python/mlad/core/libs/utils.py
@@ -98,12 +98,21 @@ def change_key_style(dct):
 
 
 # Manage Project and Network
-def base_labels(workspace: str, session: str, manifest: Dict):
+def base_labels(workspace: str, session: str, manifest: Dict, build: bool = False):
     # workspace = f"{hostname}:{workspace}"
     # Server Side Config 에서 가져올 수 있는건 직접 가져온다.
     username = get_username(session)
     key = project_key(workspace)
     basename = f"{username}-{manifest['name']}-{key[:const.SHORT_LEN]}".lower()
+
+    kind = manifest['kind']
+    if not build and kind == 'Deployment':
+        import shortuuid
+        deploy_key = shortuuid.uuid()
+        key = f"{project_key(workspace)}-{deploy_key}"
+        basename = f"{username}-{manifest['name']}-{key[:const.SHORT_LEN]}-" \
+                   f"{deploy_key[:const.SHORT_LEN]}".lower()
+
     version = str(manifest['version']).lower()
     default_image = f"{username}/{manifest['name']}-{key[:const.SHORT_LEN]}:{version}".lower()
     labels = {
@@ -118,5 +127,6 @@ def base_labels(workspace: str, session: str, manifest: Dict):
         'MLAD.PROJECT.BASE': basename,
         'MLAD.PROJECT.IMAGE': default_image,
         'MLAD.PROJECT.SESSION': session,
+        'MLAD.PROJECT.KIND': manifest['kind']
     }
     return labels

--- a/python/mlad/core/libs/utils.py
+++ b/python/mlad/core/libs/utils.py
@@ -3,8 +3,9 @@ import uuid
 import json
 import base64
 import jwt
-import shortuuid
 from typing import Dict
+
+import shortuuid
 
 from mlad.core.libs import constants as const
 from mlad.core import exceptions

--- a/python/mlad/core/libs/utils.py
+++ b/python/mlad/core/libs/utils.py
@@ -3,7 +3,9 @@ import uuid
 import json
 import base64
 import jwt
+import shortuuid
 from typing import Dict
+
 from mlad.core.libs import constants as const
 from mlad.core import exceptions
 
@@ -107,7 +109,6 @@ def base_labels(workspace: str, session: str, manifest: Dict, build: bool = Fals
 
     kind = manifest['kind']
     if not build and kind == 'Deployment':
-        import shortuuid
         deploy_key = shortuuid.uuid()
         key = f"{project_key(workspace)}-{deploy_key}"
         basename = f"{username}-{manifest['name']}-{key[:const.SHORT_LEN]}-" \

--- a/python/mlad/service/routers/project.py
+++ b/python/mlad/service/routers/project.py
@@ -62,8 +62,7 @@ def projects(extra_labels: str = '', session: str = Header(None)):
 @router.get("/project/{project_key}")
 def inspect_project(project_key: str, session: str = Header(None)):
     try:
-        key = str(project_key).replace('-', '')
-        network = ctlr.get_project_network(project_key=key)
+        network = ctlr.get_project_network(project_key=project_key)
         if not network:
             raise InvalidProjectError(project_key)
         inspect = ctlr.inspect_project_network(network)
@@ -77,8 +76,7 @@ def inspect_project(project_key: str, session: str = Header(None)):
 @router.delete("/project/{project_key}")
 def remove_project(project_key: str, session: str = Header(None)):
     try:
-        key = str(project_key).replace('-','')
-        network = ctlr.get_project_network(project_key=key)
+        network = ctlr.get_project_network(project_key=project_key)
         _check_session_key(network, session)
         if not network:
             raise InvalidProjectError(project_key)           
@@ -107,13 +105,12 @@ def project_log(project_key: str, tail: str = Query('all'),
 
     selected = True if names_or_ids else False
     try:
-        key = str(project_key).replace('-', '')
-        network = ctlr.get_project_network(project_key=key)
+        network = ctlr.get_project_network(project_key=project_key)
         if not network:
             raise InvalidProjectError(project_key)
 
         try:
-            targets = ctlr.get_service_with_names_or_ids(key, names_or_ids)
+            targets = ctlr.get_service_with_names_or_ids(project_key, names_or_ids)
         except exceptions.NotFound as e:
             if 'running' in str(e):
                 raise InvalidLogRequest("Cannot find running services.")
@@ -134,7 +131,7 @@ def project_log(project_key: str, tail: str = Query('all'),
 
         handler = disconnectHandler()
 
-        logs = ctlr.get_project_logs(key, tail, follow, timestamps, selected, handler, targets)
+        logs = ctlr.get_project_logs(project_key, tail, follow, timestamps, selected, handler, targets)
 
         def get_logs(logs):
             for _ in logs:
@@ -157,8 +154,7 @@ def project_log(project_key: str, tail: str = Query('all'),
 @router.get("/project/{project_key}/resource")
 def project_resource(project_key: str, session: str = Header(None)):
     try:
-        key = project_key.replace('-', '')
-        res = ctlr.get_project_resources(key)
+        res = ctlr.get_project_resources(project_key)
         return res
     except Exception as e:
         raise HTTPException(status_code=500, detail=exception_detail(e))

--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,8 @@ def main():
         'kubernetes>=12.0.0,<13.0.0',
         'PyJWT>=2.1.0,<3.0.0',
         'Cerberus>=1.3.0,<1.4.0',
-        'cerberus-kind==0.0.4'
+        'cerberus-kind==0.0.4',
+        'shortuuid>=1.0.1,<1.1.0'
       ],
       entry_points='''
         [console_scripts]


### PR DESCRIPTION
mlad deploy serve -f
mlad deploy kill PROJECT_KEY

- 기존 project key를 uuid type으로 다루던 부분 str으로 통일
- mlad build 또는 mlad train 은 project key를 기존대로 생성하고 
- mlad deploy 시 뒤에 uuid를 붙여 만들고, image는 기존 project key로 찾습니다