### PR TITLE
feature: MLADException 정의하고 print하도록 처리

### DIFF
--- a/python/mlad/api/exceptions.py
+++ b/python/mlad/api/exceptions.py
@@ -1,8 +1,9 @@
 import json
 from requests.exceptions import HTTPError
+from mlad.core.exceptions import MLADException
 
 
-class APIError(Exception):
+class APIError(MLADException):
     def __init__(self, msg, response=None):
         if isinstance(msg, list):
             msg = str(msg)

--- a/python/mlad/cli/__init__.py
+++ b/python/mlad/cli/__init__.py
@@ -10,8 +10,8 @@ def echo_exception(func):
         try:
             func(*args, **kwargs)
         except MLADException as e:
-            click.echo(traceback.format_exc())
             click.echo(f'{e.__class__.__name__}: {e}')
         except Exception as e:
+            click.echo(traceback.format_exc())
             click.echo(f'{e.__class__.__name__}: {e}')
     return decorated

--- a/python/mlad/cli/__init__.py
+++ b/python/mlad/cli/__init__.py
@@ -1,5 +1,7 @@
 import click
+import traceback
 from functools import wraps
+from mlad.core.exceptions import MLADException
 
 
 def echo_exception(func):
@@ -7,6 +9,9 @@ def echo_exception(func):
     def decorated(*args, **kwargs):
         try:
             func(*args, **kwargs)
+        except MLADException as e:
+            click.echo(traceback.format_exc())
+            click.echo(f'{e.__class__.__name__}: {e}')
         except Exception as e:
             click.echo(f'{e.__class__.__name__}: {e}')
     return decorated

--- a/python/mlad/cli/exceptions.py
+++ b/python/mlad/cli/exceptions.py
@@ -1,12 +1,11 @@
-class Duplicated(Exception):
+from mlad.core.exceptions import MLADException
+
+
+class InvalidURLError(MLADException):
     pass
 
 
-class TokenError(Exception):
-    pass
-
-
-class ImageNotFoundError(Exception):
+class ImageNotFoundError(MLADException):
 
     def __init__(self, name: str):
         self._name = name
@@ -15,7 +14,7 @@ class ImageNotFoundError(Exception):
         return f'Cannot find built image of the project [{self._name}].'
 
 
-class ContextAlreadyExistError(Exception):
+class ContextAlreadyExistError(MLADException):
 
     def __init__(self, name: str):
         self._name = name
@@ -24,7 +23,7 @@ class ContextAlreadyExistError(Exception):
         return f'The context [{self._name}] already exists.'
 
 
-class ContextNotFoundError(Exception):
+class ContextNotFoundError(MLADException):
 
     def __init__(self, name: str):
         self._name = name
@@ -33,13 +32,13 @@ class ContextNotFoundError(Exception):
         return f'There is no context [{self._name}] in contexts.'
 
 
-class CannotDeleteContextError(Exception):
+class CannotDeleteContextError(MLADException):
 
     def __str__(self):
         return 'The current context cannot be delete, please change the context.'
 
 
-class InvalidPropertyError(Exception):
+class InvalidPropertyError(MLADException):
 
     def __init__(self, arg: str):
         self._arg = arg
@@ -48,25 +47,25 @@ class InvalidPropertyError(Exception):
         return f'There is no matched key in "{self._arg}".'
 
 
-class MLADBoardNotActivatedError(Exception):
+class MLADBoardNotActivatedError(MLADException):
 
     def __str__(self):
         return 'The MLAD dashboard is not activated.'
 
 
-class MLADBoardAlreadyActivatedError(Exception):
+class MLADBoardAlreadyActivatedError(MLADException):
 
     def __str__(self):
         return 'The MLAD dashboard is already activated at localhost:2021.'
 
 
-class BoardImageNotExistError(Exception):
+class BoardImageNotExistError(MLADException):
 
     def __str__(self):
         return 'The MLAD dashboard image does not exist.'
 
 
-class ComponentImageNotExistError(Exception):
+class ComponentImageNotExistError(MLADException):
 
     def __init__(self, name):
         self.name = name
@@ -75,13 +74,13 @@ class ComponentImageNotExistError(Exception):
         return f'The component [{self.name}] image does not exist.'
 
 
-class CannotBuildComponentError(Exception):
+class CannotBuildComponentError(MLADException):
 
     def __str__(self):
         return 'The component spec does not have `workspace` property to build an image.'
 
 
-class ProjectAlreadyExistError(Exception):
+class ProjectAlreadyExistError(MLADException):
 
     def __init__(self, project_key: str):
         self.project_key = project_key
@@ -90,7 +89,7 @@ class ProjectAlreadyExistError(Exception):
         return f'Failed to create a project: [{self.project_key}] already exists.'
 
 
-class InvalidProjectKindError(Exception):
+class InvalidProjectKindError(MLADException):
 
     def __init__(self, kind: str, command: str = 'train'):
         self.kind = kind
@@ -100,7 +99,7 @@ class InvalidProjectKindError(Exception):
         return f'Only kind "{self.kind}" is valid for "{self.command}" command.'
 
 
-class InvalidUpdateOptionError(Exception):
+class InvalidUpdateOptionError(MLADException):
 
     def __init__(self, key: str):
         self.key = key

--- a/python/mlad/cli/libs/exceptions.py
+++ b/python/mlad/cli/libs/exceptions.py
@@ -1,2 +1,0 @@
-class InvalidURLError(Exception):
-    pass

--- a/python/mlad/cli/libs/utils.py
+++ b/python/mlad/cli/libs/utils.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 from omegaconf import OmegaConf
 from getpass import getuser
 
-from mlad.cli.libs.exceptions import InvalidURLError
+from mlad.cli.exceptions import InvalidURLError
 
 if TYPE_CHECKING:
     from mlad.cli.context import Context

--- a/python/mlad/cli/validator/exceptions.py
+++ b/python/mlad/cli/validator/exceptions.py
@@ -1,6 +1,9 @@
-class InvalidProjectYaml(Exception):
+from mlad.core.exceptions import MLADException
+
+
+class InvalidProjectYaml(MLADException):
     pass
 
 
-class InvalidComponentYaml(Exception):
+class InvalidComponentYaml(MLADException):
     pass

--- a/python/mlad/core/exceptions.py
+++ b/python/mlad/core/exceptions.py
@@ -1,15 +1,15 @@
 import json
 
 
+class MLADException(Exception):
+    pass
+
+
 class AlreadyExist(Exception):
     pass
 
 
-class Duplicated(Exception):
-    pass
-
-
-class TokenError(Exception):
+class Duplicated(MLADException):
     pass
 
 
@@ -21,7 +21,7 @@ class NotFound(Exception):
     pass
 
 
-class APIError(Exception):
+class APIError(MLADException):
     # k8s api error
     def __init__(self, msg, status_code):
         self.msg = msg
@@ -43,7 +43,7 @@ def handle_k8s_api_error(e):
     return msg, status
 
 
-class NamespaceAlreadyExistError(Exception):
+class NamespaceAlreadyExistError(MLADException):
 
     def __init__(self, key: str):
         self.key = key
@@ -52,13 +52,7 @@ class NamespaceAlreadyExistError(Exception):
         return f'Already exist the namespace, key: [{self.key}]'
 
 
-class DockerError(Exception):
-
-    def __str__(self):
-        return 'Invalid docker environment, please install a docker daemon.'
-
-
-class DeprecatedError(Exception):
+class DeprecatedError(MLADException):
 
     def __init__(self, option: str):
         self.option = option
@@ -67,7 +61,7 @@ class DeprecatedError(Exception):
         return f'Cannot deploy app for deprecated kind \'{self.option}\'.'
 
 
-class DockerNotFoundError(Exception):
+class DockerNotFoundError(MLADException):
 
     def __str__(self):
         return 'Need to install the docker daemon.'

--- a/python/mlad/core/exceptions.py
+++ b/python/mlad/core/exceptions.py
@@ -5,19 +5,15 @@ class MLADException(Exception):
     pass
 
 
-class AlreadyExist(Exception):
-    pass
-
-
 class Duplicated(MLADException):
     pass
 
 
-class NotSupportURL(Exception):
+class NotSupportURL(MLADException):
     pass
 
 
-class NotFound(Exception):
+class NotFound(MLADException):
     pass
 
 

--- a/python/mlad/service/exceptions.py
+++ b/python/mlad/service/exceptions.py
@@ -1,4 +1,7 @@
-class InvalidProjectError(Exception):
+from mlad.core.exceptions import MLADException
+
+
+class InvalidProjectError(MLADException):
     def __init__(self, project_id):
         self.project_id = project_id
 
@@ -6,7 +9,7 @@ class InvalidProjectError(Exception):
         return f'Cannot find project {self.project_id}'
 
 
-class InvalidAppError(Exception):
+class InvalidAppError(MLADException):
     def __init__(self, project_id, app_id):
         self.project_id = project_id
         self.app_id = app_id
@@ -16,7 +19,7 @@ class InvalidAppError(Exception):
                 f'in project {self.project_id}')
 
 
-class InvalidSessionError(Exception):
+class InvalidSessionError(MLADException):
     def __init__(self, app=False):
         self.target = 'App' if app else 'Project'
 
@@ -25,11 +28,7 @@ class InvalidSessionError(Exception):
                f'the project creator'
 
 
-class InvalidLogRequest(Exception):
-    pass
-
-
-class TokenError(Exception):
+class InvalidLogRequest(MLADException):
     pass
 
 
@@ -46,8 +45,6 @@ def exception_detail(e):
         reason = 'ProjectNotFound'
     elif exception == 'InvalidLogRequest':
         reason = 'AppNotRunning'
-    elif exception == 'TokenError':
-        reason = exception
     else:
         reason = 'InternalError'
         # reason = exception

--- a/python/mlad/service/routers/app.py
+++ b/python/mlad/service/routers/app.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 from typing import List
 from fastapi import APIRouter, Query, Header, HTTPException
 from fastapi.responses import StreamingResponse
@@ -48,6 +49,7 @@ def send_apps_list(labels: List[str] = Query(None), session: str = Header(None))
     except InvalidProjectError as e:
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
 
 
@@ -71,6 +73,7 @@ def send_apps(project_key: str, labels: List[str] = Query(None), session: str = 
     except InvalidProjectError as e:
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
 
 
@@ -89,6 +92,7 @@ def create_app(project_key: str, req: app_models.CreateRequest,
     except APIError as e:
         raise HTTPException(status_code=e.status_code, detail=exception_detail(e))
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
 
 
@@ -102,6 +106,7 @@ def inspect_app(project_key: str, app_name: str, session: str = Header(None)):
     except InvalidAppError as e:
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
 
 
@@ -115,6 +120,7 @@ def inspect_tasks(project_key: str, app_name: str, session: str = Header(None)):
     except InvalidAppError as e:
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
 
 
@@ -128,6 +134,7 @@ def scale_app(project_key: str, app_name: str, req: app_models.ScaleRequest, ses
     except InvalidAppError as e:
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
     return {'message': f'App {app_name} scale updated'}
 
@@ -166,6 +173,7 @@ def remove_apps(project_key: str, req: app_models.RemoveRequest,
     except InvalidSessionError as e:
         raise HTTPException(status_code=401, detail=exception_detail(e))
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
     if stream:
         return StreamingResponse(stringify_response(res), background=handler)

--- a/python/mlad/service/routers/node.py
+++ b/python/mlad/service/routers/node.py
@@ -1,3 +1,5 @@
+import traceback
+
 from typing import List
 from fastapi import APIRouter, Query, Header, HTTPException
 from mlad.core import exceptions
@@ -17,6 +19,7 @@ def node_list(session: str = Header(None)):
         return [ctlr.inspect_node(node) for node in nodes.values()]
     except Exception as e:
         logger.error(e)
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
 
 
@@ -36,4 +39,5 @@ def node_resource(names: List[str] = Query(None)):
         raise HTTPException(status_code=400, detail=exception_detail(e))
     except Exception as e:
         logger.error(e)
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))

--- a/python/mlad/service/routers/project.py
+++ b/python/mlad/service/routers/project.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 from fastapi import APIRouter, Query, HTTPException, Header
 from fastapi.responses import StreamingResponse
 from mlad.service.models import project
@@ -39,6 +40,7 @@ def create_project(req: project.CreateRequest, allow_reuse: bool = Query(False),
     except TypeError as e:
         raise HTTPException(status_code=500, detail=exception_detail(e))
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=400, detail=exception_detail(e))
 
 
@@ -53,6 +55,7 @@ def projects(extra_labels: str = '', session: str = Header(None)):
                 projects.append(spec)
         return projects
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
 
 
@@ -67,6 +70,7 @@ def inspect_project(project_key: str, session: str = Header(None)):
     except InvalidProjectError as e:
         raise HTTPException(status_code=404, detail=exception_detail(e))
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
 
 
@@ -90,6 +94,7 @@ def remove_project(project_key: str, session: str = Header(None)):
     except InvalidSessionError as e:
         raise HTTPException(status_code=401, detail=exception_detail(e))
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
 
 
@@ -145,6 +150,7 @@ def send_project_log(project_key: str, tail: str = Query('all'),
     except InvalidLogRequest as e:
         raise HTTPException(status_code=400, detail=exception_detail(e))
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
 
 
@@ -154,6 +160,7 @@ def project_resource(project_key: str, session: str = Header(None)):
         res = ctlr.get_project_resources(project_key)
         return res
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))
 
 
@@ -167,4 +174,5 @@ def update_project(project_key: str, req: project.UpdateRequest):
         res = ctlr.update_apps(namespace, apps)
         return [ctlr.inspect_app(_) for _ in res]
     except Exception as e:
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail=exception_detail(e))

--- a/python/tests/context/test_add.py
+++ b/python/tests/context/test_add.py
@@ -5,7 +5,7 @@ import pytest
 from omegaconf import OmegaConf
 from mlad.cli import context
 from mlad.cli.exceptions import ContextAlreadyExistError
-from mlad.cli.libs.exceptions import InvalidURLError
+from mlad.cli.exceptions import InvalidURLError
 
 from . import mock
 


### PR DESCRIPTION
Resolves #156 

모든 exception들이 `MLADException`를 상속받도록 하여 불필요하게 traceback을 print하지 않도록 변경하였습니다.

API server에서 정상적인 오류가 아닌 exception이 발생했을 때 traceback을 print하도록 변경하였습니다.