### PR TITLE
fix: event의 time 정보를 kubeclient 버전에 관련없이 가져올 수 있도록 동일 속성으로 변경

### DIFF
--- a/python/mlad/cli/project.py
+++ b/python/mlad/cli/project.py
@@ -1,4 +1,5 @@
 import sys
+import datetime
 
 from typing import Optional, List
 
@@ -16,8 +17,11 @@ def _parse_log(log, max_name_width=32, len_short_id=10):
         name = f"{name}.{log['task_id'][:len_short_id]}"
         namewidth = min(max_name_width, namewidth + len_short_id + 1)
     msg = log['stream'] if isinstance(log['stream'], str) else log['stream'].decode()
-    timestamp = f'[{log["timestamp"]}]' if 'timestamp' in log else None
-    return name, namewidth, msg, timestamp
+
+    timestamp = f'{log["timestamp"]}' if 'timestamp' in log else None
+    dt = datetime.datetime.fromisoformat(timestamp) + datetime.timedelta(hours=9)
+    dt = f'[{dt.strftime("%Y-%m-%d %H:%M:%S")}]'
+    return name, namewidth, msg, dt
 
 
 def _print_log(log, colorkey, max_name_width=32, len_short_id=10):

--- a/python/mlad/core/kubernetes/controller.py
+++ b/python/mlad/core/kubernetes/controller.py
@@ -359,7 +359,7 @@ def get_pod_events(pod, cli=DEFAULT_CLI):
     namespace = pod.metadata.namespace
 
     events = api.list_namespaced_event(namespace, field_selector='type=Warning').items
-    return [{'name': name, 'message': e.message, 'datetime': e.event_time}
+    return [{'name': name, 'message': e.message, 'datetime': e.metadata.creation_timestamp}
             for e in events if e.involved_object.name == name]
 
 


### PR DESCRIPTION
Resolve #192 

kube client 버전에 따라 api에서 주는 속성 정보가 달라지는 것으로 파악하여 creation_timestamp 로 변경