### PR TITLE
fix: config get이 Context를 return하지 않던 문제 수정

### DIFF
--- a/python/mlad/cli/config_cli.py
+++ b/python/mlad/cli/config_cli.py
@@ -32,7 +32,10 @@ def set(args):
 def get(key: Optional[str]):
     '''Get configurations'''
     ret = config.get(key)
-    click.echo(ret)
+    try:
+        click.echo(OmegaConf.to_yaml(ret)[:-1])
+    except ValueError:
+        click.echo(ret)
 
 
 @click.command()

--- a/python/mlad/cli/context.py
+++ b/python/mlad/cli/context.py
@@ -164,7 +164,7 @@ def get(name: str, key: Optional[str] = None) -> Context:
     if context is None:
         raise ContextNotFoundError(name)
     if key is None:
-        return OmegaConf.to_yaml(context)
+        return context
     else:
         try:
             keys = key.split('.')

--- a/python/mlad/cli/context.py
+++ b/python/mlad/cli/context.py
@@ -173,10 +173,7 @@ def get(name: str, key: Optional[str] = None) -> Context:
                 value = value[k]
         except omegaconf.errors.ConfigKeyError:
             raise InvalidPropertyError(key)
-        try:
-            return OmegaConf.to_yaml(value)[:-1]
-        except ValueError:
-            return value
+        return value
 
 
 def set(name: str, *args) -> None:

--- a/python/mlad/cli/context_cli.py
+++ b/python/mlad/cli/context_cli.py
@@ -62,7 +62,10 @@ def delete(name: str):
 def get(name: str, key: Optional[str]):
     """Display lower-level information on the context."""
     ret = context.get(name, key)
-    click.echo(ret)
+    try:
+        click.echo(OmegaConf.to_yaml(ret)[:-1])
+    except ValueError:
+        click.echo(ret)
 
 
 @click.command()


### PR DESCRIPTION
다른 cli 모듈들이 `config_core.get()` 방식으로 config를 사용하는데 Context 객체가 아닌 string 타입을 쓰면 문제가 발생합니다. 따라서 `*_cli.py` 레이어에서 stringify를 하도록 변경하였습니다.