### PR TITLE
fix: pod condition reason이 없는 경우 pod status reason으로 처리

### DIFF
--- a/python/mlad/core/kubernetes/controller.py
+++ b/python/mlad/core/kubernetes/controller.py
@@ -459,7 +459,8 @@ def get_pod_info(pod):
         pod_info['status'] = {
             'state': 'Waiting',
             'detail': {
-                'reason': pod.status.conditions[0].reason if pod.status.conditions else None
+                'reason': pod.status.conditions[0].reason if pod.status.conditions
+                else pod.status.reason
             }
         }
     return pod_info


### PR DESCRIPTION
- pod evicted 인 경우 mlad status(k8s상에서 reason) 가 None으로 처리되면서 에러 발생
- pod status condition 이 존재하지 않는 경우를 reason을 None으로 보냈었는데 이 같은 경우를 pod status reason 으로 전달하도록 변경