### PR TITLE
DB 설정이 제대로 안되어있을 때 board 실행이 제대로 안되도록 수정

### DIFF
--- a/dashboard/backend/mlad/app.py
+++ b/dashboard/backend/mlad/app.py
@@ -7,7 +7,7 @@ import aiohttp
 from typing import Callable
 from collections import defaultdict
 
-from fastapi import FastAPI, WebSocket
+from fastapi import FastAPI, HTTPException, WebSocket
 from starlette.websockets import WebSocketDisconnect
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 from .model import ComponentDeleteRequestModel, ComponentPostRequestModel
@@ -33,6 +33,7 @@ async def _request_resources(key: str, session: aiohttp.ClientSession, group_by:
         return await resp.json()
 
 
+# dashbaord의 node tab에서 보여줄 정보 반환하는 함수
 async def request_nodes(_, session: aiohttp.ClientSession):
     ret = []
     nodes = []
@@ -65,6 +66,7 @@ async def request_nodes(_, session: aiohttp.ClientSession):
     return sorted(ret, key=lambda x: x['hostname'])
 
 
+# dashboard에서 project tab에서 보여주는 project 목록 정보를 반환하는 함수
 async def request_projects(_, session: aiohttp.ClientSession):
     ret = []
     projects = []
@@ -112,9 +114,13 @@ async def request_projects(_, session: aiohttp.ClientSession):
 
 
 def get_components(_):
-    return db_client.get_components()
+    try:
+        return db_client.get_components()
+    except Exception:
+        raise HTTPException(500, detail='DB Connection is refused')
 
 
+# project tab에서 project detail 화면을 보여주기 위한 함수
 async def request_project_detail(data: str, session: aiohttp.ClientSession):
     data = json.loads(data)
     if len(data) == 0:
@@ -142,7 +148,10 @@ async def request_project_detail(data: str, session: aiohttp.ClientSession):
 
 @app.post('/component')
 def run_components(req: ComponentPostRequestModel):
-    db_client.run_component(req.components)
+    try:
+        db_client.run_component(req.components)
+    except Exception:
+        raise HTTPException(500, detail='DB connection is refused.')
     return {
         'message': 'Successfully run components'
     }
@@ -150,7 +159,10 @@ def run_components(req: ComponentPostRequestModel):
 
 @app.delete('/component')
 def delete_components(req: ComponentDeleteRequestModel):
-    db_client.delete_component(req.name)
+    try:
+        db_client.delete_component(req.name)
+    except Exception:
+        raise HTTPException(500, detail='DB connection is refused.')
     return {
         'message': f'Successfully delete component [{req.name}]'
     }

--- a/dashboard/backend/mlad/db.py
+++ b/dashboard/backend/mlad/db.py
@@ -1,6 +1,6 @@
 import os
 
-from typing import List, Dict
+from typing import List, Dict, Optional
 from pymongo import MongoClient
 from .model import ComponentPostModel
 
@@ -9,9 +9,15 @@ from .model import ComponentPostModel
 
 
 class DBClient:
+    '''
+    Component 설치에 관한 메타데이터를 관리하기 위한 client
+    '''
+    client: Optional[MongoClient]
 
     def __init__(self):
-        self.client = MongoClient(self._get_url())
+        self.client = MongoClient(
+            self._get_url(), connectTimeoutMS=2000, serverSelectionTimeoutMS=2000)
+        self.client.server_info()
 
     def _get_url(self):
         address = os.environ['DB_ADDRESS']

--- a/python/mlad/cli/board.py
+++ b/python/mlad/cli/board.py
@@ -201,6 +201,8 @@ def uninstall(name: str) -> None:
             'name': name
         })
         res.raise_for_status()
+    except requests.exceptions.HTTPError:
+        raise ComponentInstallError(res.json().get('detail', ''))
     except requests.ConnectionError:
         raise MLADBoardConnectionRefusedError
 

--- a/python/mlad/cli/exceptions.py
+++ b/python/mlad/cli/exceptions.py
@@ -110,6 +110,15 @@ class MLADBoardAlreadyActivatedError(MLADException):
         return 'The MLAD dashboard is already activated at localhost:2021.'
 
 
+class MLADBoardImageNotFoundError(MLADException):
+
+    def __init__(self, repository):
+        self.repository = repository
+
+    def __str__(self):
+        return f'No such image: {self.repository}.'
+
+
 class ComponentImageNotExistError(MLADException):
 
     def __init__(self, name):
@@ -117,6 +126,15 @@ class ComponentImageNotExistError(MLADException):
 
     def __str__(self):
         return f'The component [{self.name}] image does not exist.'
+
+
+class ComponentInstallError(MLADException):
+
+    def __init__(self, detail):
+        self.detail = detail
+
+    def __str__(self):
+        return self.detail
 
 
 class CannotBuildComponentError(MLADException):

--- a/python/mlad/cli/exceptions.py
+++ b/python/mlad/cli/exceptions.py
@@ -104,6 +104,12 @@ class MLADBoardNotActivatedError(MLADException):
         return 'The MLAD dashboard is not activated.'
 
 
+class MLADBoardConnectionRefusedError(MLADException):
+
+    def __str__(self):
+        return 'Cannot connect to the MLAD board.'
+
+
 class MLADBoardAlreadyActivatedError(MLADException):
 
     def __str__(self):


### PR DESCRIPTION
Resolves #412 

먼저, 처음 Dashboard가 켜졌을 때 connection test를 하고 실패하면 dashboard가 비정상 종료가 되도록 설정했습니다.
이에 맞춰 `mlad board status` 명령에서 종료가 된 dashboard에 대하여 로그를 띄워서 오류를 확인 할 수 있도록 구현했습니다.

처음 connection에 성공하더라도 중간에 connection이 끊켰을 때를 체크 할 수 있게 하기 위해서 DB connection is refused라는 메세지를 반환하도록 구현했고 이를 MLAD CLI쪽에서 감지해서 출력하도록 했습니다.

그 외,
* activate 단계에서 image repository가 잘못 된 경우 예외 처리를 추가했습니다.
* install, uninstall 단계에서 mlad board와의 연결에 대한 예외 처리를 추가했습니다.